### PR TITLE
Fix relative paths and add CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,3 +14,10 @@ jobs:
         with:
           node-version: 20
       - run: node scripts/validate.mjs
+
+      - name: Validate SKILL.md (Agent Skills spec)
+        uses: Flash-Brew-Digital/validate-skill@v1
+        with:
+          path: ./skills/powersync
+          validate-references: true
+          fail-on-warning: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,16 @@
+name: Validate Skills
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/validate.mjs

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "PowerSync Agent Skills for developers building applications with PowerSync.",
   "main": "",
+  "scripts": {
+    "validate": "node scripts/validate.mjs"
+  },
   "keywords": [],
   "author": "",
   "license": "CC0-1.0",

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+
+/**
+ * Validates agent skills against the Agent Skills specification (agentskills.io)
+ * and verifies the Claude plugin marketplace manifest.
+ *
+ * Usage: node scripts/validate.mjs
+ */
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+let errors = 0;
+let warnings = 0;
+
+function error(msg) {
+  console.error(`  ✗ ${msg}`);
+  errors++;
+}
+
+function warn(msg) {
+  console.warn(`  ⚠ ${msg}`);
+  warnings++;
+}
+
+function pass(msg) {
+  console.log(`  ✓ ${msg}`);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Validate SKILL.md frontmatter and structure
+// ---------------------------------------------------------------------------
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^(\w[\w-]*):\s*(.+)/);
+    if (kv) fm[kv[1]] = kv[2].replace(/^["']|["']$/g, '');
+  }
+  return fm;
+}
+
+function validateSkillMd(skillDir, skillName) {
+  console.log(`\n[SKILL.md] ${skillName}`);
+  const skillMdPath = join(skillDir, 'SKILL.md');
+
+  if (!existsSync(skillMdPath)) {
+    error('SKILL.md not found');
+    return;
+  }
+
+  const content = readFileSync(skillMdPath, 'utf-8');
+  const fm = parseFrontmatter(content);
+
+  if (!fm) {
+    error('No YAML frontmatter found (must be between --- markers)');
+    return;
+  }
+
+  // name field
+  if (!fm.name) {
+    error('Missing required field: name');
+  } else {
+    if (fm.name.length > 64) error(`name exceeds 64 characters (${fm.name.length})`);
+    if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(fm.name)) error(`name "${fm.name}" must be lowercase alphanumeric with hyphens, no leading/trailing hyphens`);
+    if (/--/.test(fm.name)) error(`name "${fm.name}" must not contain consecutive hyphens`);
+    if (fm.name !== skillName) error(`name "${fm.name}" must match directory name "${skillName}"`);
+    if (fm.name === skillName) pass(`name matches directory: ${fm.name}`);
+  }
+
+  // description field
+  if (!fm.description) {
+    error('Missing required field: description');
+  } else {
+    if (fm.description.length > 1024) error(`description exceeds 1024 characters (${fm.description.length})`);
+    if (fm.description.length < 50) warn(`description is short (${fm.description.length} chars) — consider adding more detail`);
+    pass('description present');
+  }
+
+  // body length
+  const bodyStart = content.indexOf('---', content.indexOf('---') + 3) + 3;
+  const body = content.slice(bodyStart).trim();
+  const bodyLines = body.split('\n').length;
+  if (bodyLines > 500) warn(`SKILL.md body is ${bodyLines} lines — spec recommends < 500`);
+  pass(`body length: ${bodyLines} lines`);
+
+  // companion files
+  for (const companion of ['AGENTS.md', 'CLAUDE.md']) {
+    if (existsSync(join(skillDir, companion))) {
+      pass(`${companion} exists`);
+    } else {
+      warn(`${companion} not found — recommended for multi-agent compatibility`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Validate file references resolve
+// ---------------------------------------------------------------------------
+
+function extractReferences(content) {
+  const refs = new Set();
+
+  // Backtick references to .md files: `references/sdks/powersync-js.md`
+  for (const m of content.matchAll(/`((?:references|scripts|assets)\/[^`]+\.md)`/g)) {
+    refs.add(m[1]);
+  }
+
+  // Markdown link references to local .md files: [text](references/foo.md)
+  for (const m of content.matchAll(/\]\(((?:references|scripts|assets)\/[^)]+\.md)\)/g)) {
+    refs.add(m[1]);
+  }
+
+  return refs;
+}
+
+function validateReferences(skillDir, skillName) {
+  console.log(`\n[References] ${skillName}`);
+
+  const mdFiles = [];
+  function collectMd(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) collectMd(full);
+      else if (entry.name.endsWith('.md')) mdFiles.push(full);
+    }
+  }
+  collectMd(skillDir);
+
+  let totalRefs = 0;
+  let brokenRefs = 0;
+
+  for (const file of mdFiles) {
+    const content = readFileSync(file, 'utf-8');
+    const refs = extractReferences(content);
+    const relFile = file.replace(skillDir + '/', '');
+
+    for (const ref of refs) {
+      totalRefs++;
+      const resolved = join(skillDir, ref);
+      if (!existsSync(resolved)) {
+        error(`${relFile} → ${ref} (file not found)`);
+        brokenRefs++;
+      }
+    }
+  }
+
+  if (brokenRefs === 0 && totalRefs > 0) {
+    pass(`all ${totalRefs} file references resolve`);
+  } else if (totalRefs === 0) {
+    warn('no file references found');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Validate marketplace.json
+// ---------------------------------------------------------------------------
+
+function validateMarketplace() {
+  console.log('\n[Marketplace] .claude-plugin/marketplace.json');
+  const manifestPath = join(ROOT, '.claude-plugin', 'marketplace.json');
+
+  if (!existsSync(manifestPath)) {
+    warn('marketplace.json not found — skipping');
+    return;
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  } catch (e) {
+    error(`Invalid JSON: ${e.message}`);
+    return;
+  }
+
+  // name
+  if (!manifest.name) {
+    error('Missing marketplace name');
+  } else if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(manifest.name)) {
+    error(`Marketplace name "${manifest.name}" must be lowercase kebab-case`);
+  } else {
+    pass(`marketplace name: ${manifest.name}`);
+  }
+
+  // owner
+  if (!manifest.owner?.name) {
+    error('Missing owner.name');
+  } else {
+    pass(`owner: ${manifest.owner.name}`);
+  }
+
+  // plugins
+  if (!Array.isArray(manifest.plugins) || manifest.plugins.length === 0) {
+    error('plugins array is missing or empty');
+    return;
+  }
+
+  const seenNames = new Set();
+  for (const plugin of manifest.plugins) {
+    if (!plugin.name) {
+      error('Plugin missing name');
+      continue;
+    }
+    if (seenNames.has(plugin.name)) {
+      error(`Duplicate plugin name: ${plugin.name}`);
+    }
+    seenNames.add(plugin.name);
+
+    // Validate skill paths (relative to repo root)
+    if (Array.isArray(plugin.skills)) {
+      for (const skillPath of plugin.skills) {
+        const resolved = resolve(ROOT, skillPath);
+        if (!existsSync(resolved)) {
+          error(`Plugin "${plugin.name}" skill path not found: ${skillPath}`);
+        } else if (!existsSync(join(resolved, 'SKILL.md'))) {
+          error(`Plugin "${plugin.name}" skill path missing SKILL.md: ${skillPath}`);
+        } else {
+          pass(`plugin "${plugin.name}" → ${skillPath}`);
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+console.log('Validating agent skills...');
+
+// Discover all skills
+const skillsRoot = join(ROOT, 'skills');
+if (!existsSync(skillsRoot)) {
+  error('skills/ directory not found');
+} else {
+  const skillDirs = readdirSync(skillsRoot, { withFileTypes: true })
+    .filter(d => d.isDirectory() && existsSync(join(skillsRoot, d.name, 'SKILL.md')));
+
+  if (skillDirs.length === 0) {
+    error('No skills found (no directories with SKILL.md)');
+  }
+
+  for (const dir of skillDirs) {
+    const skillDir = join(skillsRoot, dir.name);
+    validateSkillMd(skillDir, dir.name);
+    validateReferences(skillDir, dir.name);
+  }
+}
+
+validateMarketplace();
+
+// Summary
+console.log('\n' + '─'.repeat(40));
+if (errors > 0) {
+  console.error(`\n✗ ${errors} error(s), ${warnings} warning(s)`);
+  process.exit(1);
+} else {
+  console.log(`\n✓ All checks passed (${warnings} warning(s))`);
+}

--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -44,11 +44,11 @@ Key rule: **client writes never go through PowerSync** — they go directly from
 |------|-----------------|
 | New project setup | See SDK Reference Files below for your platform |
 | Handling file uploads / attachments | `references/attachments.md` |
-| Debugging sync / connection issues | `powersync-debug.md` |
-| Writing or migrating sync config | `sync-config.md` |
-| Configuring the service / self-hosting | `powersync-service.md` |
-| Using the PowerSync CLI | `powersync-cli.md` |
-| Understanding the overall architecture | This file is sufficient; see `powersync-overview.md` for deep links |
+| Debugging sync / connection issues | `references/powersync-debug.md` |
+| Writing or migrating sync config | `references/sync-config.md` |
+| Configuring the service / self-hosting | `references/powersync-service.md` |
+| Using the PowerSync CLI | `references/powersync-cli.md` |
+| Understanding the overall architecture | This file is sufficient; see `references/powersync-overview.md` for deep links |
 
 ## SDK Reference Files
 
@@ -58,20 +58,20 @@ Always load `references/sdks/powersync-js.md` as the foundation for any JS/TS pr
 
 | Framework file | Load when… |
 |----------------|-----------|
-| `powersync-js-react.md` | React web app or Next.js |
-| `powersync-js-react-native.md` | React Native, Expo, or Expo Go |
-| `powersync-js-vue.md` | Vue or Nuxt |
-| `powersync-js-node.md` | Node.js CLI/server or Electron |
-| `powersync-js-tanstack.md` | TanStack Query or TanStack DB (any framework) |
+| `references/sdks/powersync-js-react.md` | React web app or Next.js |
+| `references/sdks/powersync-js-react-native.md` | React Native, Expo, or Expo Go |
+| `references/sdks/powersync-js-vue.md` | Vue or Nuxt |
+| `references/sdks/powersync-js-node.md` | Node.js CLI/server or Electron |
+| `references/sdks/powersync-js-tanstack.md` | TanStack Query or TanStack DB (any framework) |
 
 ### Other SDKs
 
 | File | Use when… |
 |------|----------|
-| `powersync-dart.md` | Dart / Flutter (includes Drift ORM + Flutter Web) |
-| `powersync-dotnet.md` | .NET (MAUI, WPF, Console) |
-| `powersync-kotlin.md` | Kotlin Multiplatform (Android, JVM, iOS, macOS, watchOS, tvOS) |
-| `powersync-swift.md` | Swift / iOS / macOS (includes GRDB ORM) |
+| `references/sdks/powersync-dart.md` | Dart / Flutter (includes Drift ORM + Flutter Web) |
+| `references/sdks/powersync-dotnet.md` | .NET (MAUI, WPF, Console) |
+| `references/sdks/powersync-kotlin.md` | Kotlin Multiplatform (Android, JVM, iOS, macOS, watchOS, tvOS) |
+| `references/sdks/powersync-swift.md` | Swift / iOS / macOS (includes GRDB ORM) |
 
 ## Key Rules to Apply Without Being Asked
 

--- a/skills/powersync/SKILL.md
+++ b/skills/powersync/SKILL.md
@@ -56,11 +56,11 @@ Key rule: **client writes never go through PowerSync** — they go directly from
 |------|-----------------|
 | New project setup | See SDK Reference Files below for your platform |
 | Handling file uploads / attachments | `references/attachments.md` |
-| Debugging sync / connection issues | `powersync-debug.md` |
-| Writing or migrating sync config | `sync-config.md` |
-| Configuring the service / self-hosting | `powersync-service.md` |
-| Using the PowerSync CLI | `powersync-cli.md` |
-| Understanding the overall architecture | This file is sufficient; see `powersync-overview.md` for deep links |
+| Debugging sync / connection issues | `references/powersync-debug.md` |
+| Writing or migrating sync config | `references/sync-config.md` |
+| Configuring the service / self-hosting | `references/powersync-service.md` |
+| Using the PowerSync CLI | `references/powersync-cli.md` |
+| Understanding the overall architecture | This file is sufficient; see `references/powersync-overview.md` for deep links |
 
 ## SDK Reference Files
 
@@ -68,22 +68,22 @@ Key rule: **client writes never go through PowerSync** — they go directly from
 
 Always load `references/sdks/powersync-js.md` as the foundation for any JS/TS project, then load the applicable framework file alongside it.
 
-| Framework file | Load when… |
-|----------------|-----------|
-| `powersync-js-react.md` | React web app or Next.js |
-| `powersync-js-react-native.md` | React Native, Expo, or Expo Go |
-| `powersync-js-vue.md` | Vue or Nuxt |
-| `powersync-js-node.md` | Node.js CLI/server or Electron |
-| `powersync-js-tanstack.md` | TanStack Query or TanStack DB (any framework) |
+| Framework | Load when… | File |
+|-----------|-----------|------|
+| React / Next.js | React web app or Next.js | `references/sdks/powersync-js-react.md` |
+| React Native / Expo | React Native, Expo, or Expo Go | `references/sdks/powersync-js-react-native.md` |
+| Vue / Nuxt | Vue or Nuxt | `references/sdks/powersync-js-vue.md` |
+| Node.js / Electron | Node.js CLI/server or Electron | `references/sdks/powersync-js-node.md` |
+| TanStack | TanStack Query or TanStack DB (any framework) | `references/sdks/powersync-js-tanstack.md` |
 
 ### Other SDKs
 
-| File | Use when… |
-|------|----------|
-| `powersync-dart.md` | Dart / Flutter (includes Drift ORM + Flutter Web) |
-| `powersync-dotnet.md` | .NET (MAUI, WPF, Console) |
-| `powersync-kotlin.md` | Kotlin Multiplatform (Android, JVM, iOS, macOS, watchOS, tvOS) |
-| `powersync-swift.md` | Swift / iOS / macOS (includes GRDB ORM) |
+| Platform | Load when… | File |
+|----------|-----------|------|
+| Dart / Flutter | Dart / Flutter (includes Drift ORM + Flutter Web) | `references/sdks/powersync-dart.md` |
+| .NET | .NET (MAUI, WPF, Console) | `references/sdks/powersync-dotnet.md` |
+| Kotlin | Kotlin Multiplatform (Android, JVM, iOS, macOS, watchOS, tvOS) | `references/sdks/powersync-kotlin.md` |
+| Swift | Swift / iOS / macOS (includes GRDB ORM) | `references/sdks/powersync-swift.md` |
 
 ## Key Rules to Apply Without Being Asked
 
@@ -93,5 +93,5 @@ Always load `references/sdks/powersync-js.md` as the foundation for any JS/TS pr
 - **No boolean/date column types** — use `column.integer` (0/1) for booleans and `column.text` (ISO string) for dates.
 - **`connect()` is fire-and-forget** — do not `await connect()` expecting data to be ready. Use `waitForFirstSync()` if you need to wait.
 - **`transaction.complete()` is mandatory** — if it is never called, the upload queue stalls permanently.
-- **`disconnectAndClear()` on logout** — `disconnect()` keeps local data; `disconnectAndClear()` wipes it. Always use `disconnectAndClear()` when switching users.
+- **`disconnectAndClear()` on logout** — `disconnect()` keeps local data; `disconnectAndClear()` wipes it. Always use `disconnectAndClear()` when switching users (this will however cause the client to do a full re-sync when connecting again).
 - **Backend must return 2xx for validation errors** — a 4xx response from `uploadData` blocks the upload queue permanently.

--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -9,7 +9,7 @@ metadata:
 
 These are debugging steps most frequently recommended by PowerSync, with an explanation of what problem each step helps identify and why it works.
 
-Make sure to understand the [PowerSync Architecture](./powersync-overview.md) before debugging.
+Make sure to understand the [PowerSync Architecture](references/powersync-overview.md) before debugging.
 
 ## Check `SyncStatus` / `currentStatus` Before Investigating Further
 

--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -11,13 +11,13 @@ Guidance for configuring PowerSync Service, sync config, and database replicatio
 
 For source code see: [powersync-service](https://github.com/powersync-ja/powersync-service/)
 
-For debugging see: [powersync-debug.md](./powersync-debug.md).
+For debugging see: [powersync-debug.md](references/powersync-debug.md).
 
 ## Sync Config
 
 The rules that instruct the PowerSync Service what data to replicate and download to client application.
 
-See [sync-config.md](sync-config.md) for detailed information.
+See [sync-config.md](references/sync-config.md) for detailed information.
 
 ## Service Configuration (Self-hosted)
 

--- a/skills/powersync/references/sdks/powersync-dart.md
+++ b/skills/powersync/references/sdks/powersync-dart.md
@@ -124,7 +124,7 @@ See [Instantiate the PowerSync Database](https://docs.powersync.com/client-sdks/
 
 ## Sync Streams
 
-See [sync-config.md](../sync-config.md) for how to subscribe to Sync Streams when `auto_subscribe` is not set to `true` in the PowerSync Service config.
+See [sync-config.md](references/sync-config.md) for how to subscribe to Sync Streams when `auto_subscribe` is not set to `true` in the PowerSync Service config.
 
 ## Query Patterns
 

--- a/skills/powersync/references/sdks/powersync-dotnet.md
+++ b/skills/powersync/references/sdks/powersync-dotnet.md
@@ -529,7 +529,7 @@ progress?.TotalOperations       // int
 
 ## Sync Streams
 
-Sync Streams are the recommended way to define what data syncs to each client. See [Sync Config](../sync-config.md) for server-side configuration (YAML definitions, parameters, CTEs) and [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md) for full examples.
+Sync Streams are the recommended way to define what data syncs to each client. See [Sync Config](references/sync-config.md) for server-side configuration (YAML definitions, parameters, CTEs) and [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md) for full examples.
 
 > Sync Streams are currently in alpha in the .NET SDK.
 

--- a/skills/powersync/references/sdks/powersync-js-node.md
+++ b/skills/powersync/references/sdks/powersync-js-node.md
@@ -7,7 +7,7 @@ metadata:
 
 # PowerSync Node.js & Electron
 
-Node.js-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `powersync-js.md` when building Node.js CLI tools, background sync processes, ETL pipelines, or Electron desktop apps.
+Node.js-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `references/sdks/powersync-js.md` when building Node.js CLI tools, background sync processes, ETL pipelines, or Electron desktop apps.
 
 | Resource | Description |
 |----------|-------------|
@@ -61,7 +61,7 @@ await db.connect(connector);
 
 ### Querying
 
-No UI hooks are available in Node.js. Use the imperative API from `powersync-js.md` directly:
+No UI hooks are available in Node.js. Use the imperative API from `references/sdks/powersync-js.md` directly:
 
 ```ts
 // One-time queries
@@ -111,7 +111,7 @@ Electron apps have two distinct environments — the renderer process (a Chromiu
 Electron App
 ├── Renderer Process (Chromium)
 │   └── Use @powersync/web + @powersync/react or @powersync/vue
-│       → See powersync-js-react.md or powersync-js-vue.md
+│       → See references/sdks/powersync-js-react.md or references/sdks/powersync-js-vue.md
 │
 └── Main Process (Node.js)
     └── Use @powersync/node + better-sqlite3
@@ -126,7 +126,7 @@ The renderer process is a full browser environment. Set it up exactly like any o
 npm install @powersync/web @journeyapps/wa-sqlite @powersync/react
 ```
 
-Use `PowerSyncContext.Provider` and `useQuery`/`useStatus` hooks as documented in `powersync-js-react.md`. The Web-Specific Options section in `powersync-js.md` (VFS options, multi-tab, `debugMode`) also applies to the renderer process.
+Use `PowerSyncContext.Provider` and `useQuery`/`useStatus` hooks as documented in `references/sdks/powersync-js-react.md`. The Web-Specific Options section in `references/sdks/powersync-js.md` (VFS options, multi-tab, `debugMode`) also applies to the renderer process.
 
 ### Main Process
 

--- a/skills/powersync/references/sdks/powersync-js-react-native.md
+++ b/skills/powersync/references/sdks/powersync-js-react-native.md
@@ -7,9 +7,9 @@ metadata:
 
 # PowerSync React Native, Expo & Expo Go
 
-React Native-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `powersync-js.md` when building React Native apps, Expo apps (managed or bare workflow), or Expo Go sandboxes.
+React Native-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `references/sdks/powersync-js.md` when building React Native apps, Expo apps (managed or bare workflow), or Expo Go sandboxes.
 
-The React hooks API (`useQuery`, `useStatus`, `usePowerSync`, `useSuspenseQuery`) from `@powersync/react-native` is identical to `@powersync/react` — see `powersync-js.md` for full hook patterns and `powersync-js-react.md` for `useSuspenseQuery` and sync stream hooks.
+The React hooks API (`useQuery`, `useStatus`, `usePowerSync`, `useSuspenseQuery`) from `@powersync/react-native` is identical to `@powersync/react` — see `references/sdks/powersync-js.md` for full hook patterns and `references/sdks/powersync-js-react.md` for `useSuspenseQuery` and sync stream hooks.
 
 | Resource | Description |
 |----------|-------------|

--- a/skills/powersync/references/sdks/powersync-js-react.md
+++ b/skills/powersync/references/sdks/powersync-js-react.md
@@ -7,7 +7,7 @@ metadata:
 
 # PowerSync React & Next.js
 
-React-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `powersync-js.md` when building React web apps, Next.js apps, or when using the React hooks from `@powersync/react` or `@powersync/react-native`.
+React-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `references/sdks/powersync-js.md` when building React web apps, Next.js apps, or when using the React hooks from `@powersync/react` or `@powersync/react-native`.
 
 | Resource | Description |
 |----------|-------------|

--- a/skills/powersync/references/sdks/powersync-js-tanstack.md
+++ b/skills/powersync/references/sdks/powersync-js-tanstack.md
@@ -7,7 +7,7 @@ metadata:
 
 # PowerSync TanStack Integrations
 
-TanStack-specific integrations for the PowerSync JavaScript SDK. Use this reference alongside `powersync-js.md` when using TanStack Query (React) or TanStack DB (multi-framework) with PowerSync.
+TanStack-specific integrations for the PowerSync JavaScript SDK. Use this reference alongside `references/sdks/powersync-js.md` when using TanStack Query (React) or TanStack DB (multi-framework) with PowerSync.
 
 | Resource | Description |
 |----------|-------------|
@@ -28,7 +28,7 @@ Use TanStack Query when you need:
 - Pagination support via TanStack's built-in paginated query patterns
 - React Suspense with navigation blocking via `v7_startTransition`
 
-Use `@powersync/react` hooks (from `powersync-js-react.md`) when:
+Use `@powersync/react` hooks (from `references/sdks/powersync-js-react.md`) when:
 - You don't need TanStack's query cache
 - You want a simpler API with fewer dependencies
 
@@ -190,7 +190,7 @@ npm ls @powersync/common
 npm ls @tanstack/react-db @tanstack/powersync-db-collection @tanstack/db
 ```
 
-If multiple versions appear, delete `node_modules` and the lock file, then reinstall. See also `powersync-debug.md` for the full debugging guidance.
+If multiple versions appear, delete `node_modules` and the lock file, then reinstall. See also `references/powersync-debug.md` for the full debugging guidance.
 
 ### Don't mix TanStack DB collections and direct `db.execute()` without accounting for optimistic state
 

--- a/skills/powersync/references/sdks/powersync-js-vue.md
+++ b/skills/powersync/references/sdks/powersync-js-vue.md
@@ -7,7 +7,7 @@ metadata:
 
 # PowerSync Vue & Nuxt
 
-Vue-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `powersync-js.md` when building Vue apps or Nuxt apps.
+Vue-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `references/sdks/powersync-js.md` when building Vue apps or Nuxt apps.
 
 | Resource | Description |
 |----------|-------------|
@@ -82,7 +82,7 @@ For advanced watch query features including incremental updates and differential
 
 #### `useStatus`
 
-Reactive connectivity status. Same shape as the React `useStatus` hook — see `powersync-js.md` for the full status field reference.
+Reactive connectivity status. Same shape as the React `useStatus` hook — see `references/sdks/powersync-js.md` for the full status field reference.
 
 ```ts
 import { useStatus } from '@powersync/vue'; // omit import in Nuxt

--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -25,11 +25,11 @@ Framework-specific files (load alongside this file):
 
 | File | Use when... |
 |------|-------------|
-| `powersync-js-react.md` | React web app or Next.js |
-| `powersync-js-react-native.md` | React Native, Expo, or Expo Go |
-| `powersync-js-vue.md` | Vue or Nuxt |
-| `powersync-js-node.md` | Node.js CLI/server or Electron |
-| `powersync-js-tanstack.md` | TanStack Query or TanStack DB (any framework) |
+| `references/sdks/powersync-js-react.md` | React web app or Next.js |
+| `references/sdks/powersync-js-react-native.md` | React Native, Expo, or Expo Go |
+| `references/sdks/powersync-js-vue.md` | Vue or Nuxt |
+| `references/sdks/powersync-js-node.md` | Node.js CLI/server or Electron |
+| `references/sdks/powersync-js-tanstack.md` | TanStack Query or TanStack DB (any framework) |
 
 ## Package Coverage
 
@@ -264,7 +264,7 @@ await db.waitForFirstSync();
 
 ### 5. Provider / Plugin Setup
 
-Framework-specific setup (React `PowerSyncContext.Provider`, Vue plugin, Nuxt plugin) is covered in the framework files. See `powersync-js-react.md`, `powersync-js-vue.md`, etc.
+Framework-specific setup (React `PowerSyncContext.Provider`, Vue plugin, Nuxt plugin) is covered in the framework files. See `references/sdks/powersync-js-react.md`, `references/sdks/powersync-js-vue.md`, etc.
 
 ### Web-Specific Options
 
@@ -613,11 +613,11 @@ const entries = db.currentStatus.priorityStatusEntries();
 
 ### Sync Streams
 
-Sync Streams are the recommended way to define what data syncs to each client. They provide on-demand subscriptions with parameters and TTL-based expiry. See [sync-config.md](../sync-config.md) for server-side configuration (YAML definitions, parameters, CTEs).
+Sync Streams are the recommended way to define what data syncs to each client. They provide on-demand subscriptions with parameters and TTL-based expiry. See [sync-config.md](references/sync-config.md) for server-side configuration (YAML definitions, parameters, CTEs).
 
 Requires the service to be configured with Sync Streams (edition 3 config). See [Sync Streams Overview](https://docs.powersync.com/sync/streams/overview.md) and [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md) for more information.
 
-The `streams` option in `useQuery` (see below) and the imperative API work across all JS/TS frameworks. Framework-specific Sync Stream hooks are covered in the respective framework files where available — for example, `useSyncStream` and `useSuspenseSyncStream` in `powersync-js-react.md`.
+The `streams` option in `useQuery` (see below) and the imperative API work across all JS/TS frameworks. Framework-specific Sync Stream hooks are covered in the respective framework files where available — for example, `useSyncStream` and `useSuspenseSyncStream` in `references/sdks/powersync-js-react.md`.
 
 #### Streams in useQuery
 

--- a/skills/powersync/references/sdks/powersync-kotlin.md
+++ b/skills/powersync/references/sdks/powersync-kotlin.md
@@ -381,7 +381,7 @@ progress?.totalOperations      // Int
 
 ## Sync Streams
 
-Sync Streams are the recommended way to define what data syncs to each client. See [Sync Config](../sync-config.md) for server-side configuration (YAML definitions, parameters, CTEs) and [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md) for full Kotlin examples.
+Sync Streams are the recommended way to define what data syncs to each client. See [Sync Config](references/sync-config.md) for server-side configuration (YAML definitions, parameters, CTEs) and [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md) for full Kotlin examples.
 
 If `auto_subscribe` is not set to `true` in the sync config, subscribe to streams from client code:
 

--- a/skills/powersync/references/sdks/powersync-swift.md
+++ b/skills/powersync/references/sdks/powersync-swift.md
@@ -137,7 +137,7 @@ See [Instantiate the PowerSync Database](https://docs.powersync.com/client-sdks/
 
 ## Sync Streams
 
-See [sync-config.md](../sync-config.md) for how to subscribe to Sync Streams when `auto_subscribe` is not set to `true` in the PowerSync Service config.
+See [sync-config.md](references/sync-config.md) for how to subscribe to Sync Streams when `auto_subscribe` is not set to `true` in the PowerSync Service config.
 
 ## Query Patterns
 


### PR DESCRIPTION
When referencing other files in your skill, use relative paths from the skill root, see [this](https://agentskills.io/specification#file-references).

- Updated `SKILL.md` and `AGENTS.md` to use full relative paths (`references/...` and `references/sdks/...`) instead of bare filenames in the reference tables and key rules section
- Updated all SDK reference files to use skill-root-relative paths for backtick and markdown link references, per the Agent Skills spec
- Updated powersync-debug.md, powersync-service.md to use skill-root-relative paths for cross-references
- Added `scripts/validate.mjs` to validate `SKILL.md` frontmatter, file references, and `marketplace.json`
- Added GitHub Actions workflow to run validation on pushes to main and PRs