### PR TITLE
Improve agent setup workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 node_modules/
 .claude
+.vscode
+/powersync

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 .claude
 .vscode
 /powersync
+/temp
+/temp-claude

--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -38,17 +38,162 @@ flowchart LR
 
 Key rule: **client writes never go through PowerSync** — they go directly from the app's upload queue to your backend API. PowerSync only handles the read/sync path.
 
+## Getting Started — PowerSync Service Setup
+
+When setting up the PowerSync Service, ask the user two questions if the answers aren't clear from context:
+1. **Cloud or Self-hosted?** — PowerSync Cloud (managed) or self-hosted (run your own Docker instance)?
+2. **Dashboard or CLI?** — For Cloud: set up via the PowerSync Dashboard UI, or via the PowerSync CLI? For Self-hosted: manual Docker setup, or use the CLI's Docker integration?
+
+Then follow the matching path below. For all paths, also load `references/powersync-service.md` and `references/sync-config.md`.
+
+### Path 1: Cloud — Dashboard Setup
+
+No CLI needed. The user does everything through the [PowerSync Dashboard](https://dashboard.powersync.com).
+
+Guide the user through these steps:
+
+1. **Sign up and create a project** — the user needs a PowerSync account at https://dashboard.powersync.com. Once signed in, they must create a project before they can create an instance.
+2. **Create a PowerSync instance** — inside the project, create a new instance.
+3. **Connect the source database** — in the instance settings, add the database connection. The user needs to provide:
+   - Database type (Postgres, MongoDB, MySQL, etc.)
+   - Connection URI or host/port/database/username/password
+   - The database must have replication enabled — see `references/powersync-service.md` → Source Database Setup for the SQL commands the user needs to run.
+4. **Configure sync rules** — in the instance's Sync Config editor, write Sync Streams that define what data each user receives. Must use `config: edition: 3`. See `references/sync-config.md` for the format.
+5. **Enable client authentication** — in the instance's "Client Auth" section, configure JWT verification (JWKS URI, Supabase Auth, etc.). For development, enable "Development Tokens" in this section.
+6. **Get the instance URL** — copy the instance URL from the dashboard. The app's `fetchCredentials()` needs this as the PowerSync endpoint.
+
+**IMPORTANT:** All steps must be completed. If any are missing, the app will be stuck on "Syncing..." with no data.
+
+### Path 2: Cloud — CLI Setup
+
+Load `references/powersync-cli.md` for full CLI reference.
+
+**What to ask the user before starting:**
+- Do they have a PowerSync account? If not, direct them to https://dashboard.powersync.com to sign up.
+- Have they created a project on the dashboard? If not, they need to create one first at https://dashboard.powersync.com (a project is required before creating an instance).
+- Do they have an existing instance, or should we create a new one?
+
+#### New Cloud Instance
+
+1. **Install and authenticate:**
+   ```bash
+   npm install -g powersync
+   powersync login
+   ```
+   `powersync login` opens a browser for the user to create/paste a personal access token (PAT). If they don't have one: https://dashboard.powersync.com/account/access-tokens
+
+2. **Scaffold config files:**
+   ```bash
+   powersync init cloud
+   ```
+   This creates `powersync/service.yaml` and `powersync/sync-config.yaml` with template values.
+
+3. **Read the scaffolded files**, then prompt the user for their database connection details and edit the files:
+   - `powersync/service.yaml` — fill in `replication.connections` with database type, host, port, database name, username, and password. For Cloud, use `password: secret: !env PS_DATABASE_PASSWORD` for credentials. See `references/powersync-service.md` for the correct YAML structure.
+   - `powersync/sync-config.yaml` — must start with `config: edition: 3`, then define `streams:`. Write Sync Streams based on the app's tables. See `references/sync-config.md`.
+
+4. **Ask the user for their project ID**, then create the instance and deploy:
+   ```bash
+   powersync link cloud --create --project-id=<project-id>
+   # Add --org-id=<org-id> only if their token has access to multiple orgs
+   powersync validate
+   powersync deploy
+   ```
+   The user can find their project ID on the PowerSync Dashboard under their project settings or by running `powersync fetch instances`.
+
+5. **Set up the source database** — the user must configure their database for replication. See `references/powersync-service.md` → Source Database Setup for the SQL commands. For Supabase, logical replication is already enabled but the user still needs to create the publication via the Supabase SQL Editor.
+
+6. **Generate a dev token** for testing:
+   ```bash
+   powersync generate token --subject=user-test-1
+   ```
+   Use this token in the app's `fetchCredentials()` during development.
+
+7. **Verify:** `powersync status` — confirm the instance is connected and replicating.
+
+#### Existing Cloud Instance
+
+**Ask the user for their project ID and instance ID**, then pull the config:
+```bash
+powersync login
+powersync pull instance --project-id=<project-id> --instance-id=<instance-id>
+# Add --org-id=<org-id> only if token has multiple orgs
+```
+The user can find these IDs on the PowerSync Dashboard or by running `powersync fetch instances`.
+
+**WARNING:** `powersync pull instance` silently overwrites local `service.yaml` and `sync-config.yaml`. Do not run it if there are uncommitted local changes to those files.
+
+After pulling, edit files as needed, then:
+```bash
+powersync validate
+powersync deploy
+```
+
+### Path 3: Self-Hosted — Manual Docker Setup
+
+No CLI needed. The user runs Docker directly with the PowerSync Service image.
+
+1. **Set up the source database** — see `references/powersync-service.md` → Source Database Setup.
+
+2. **Create the config file** — create a `config.yaml` with the correct structure. See `references/powersync-service.md` → Complete service.yaml Example. Key sections:
+   - `replication.connections` — the database connection (**must** be nested here, not at root level)
+   - `storage` — bucket storage database (MongoDB or Postgres, separate from source DB)
+   - `client_auth` — JWT verification settings
+   - `api.tokens` — API key for management access
+
+3. **Run the Docker container:**
+   ```bash
+   docker run \
+     -p 8080:80 \
+     -e POWERSYNC_CONFIG_B64="$(base64 -i ./config.yaml)" \
+     --network my-local-dev-network \
+     --name my-powersync journeyapps/powersync-service:latest
+   ```
+
+4. **Create the sync config** — write sync rules (see `references/sync-config.md`) either inline in `config.yaml` or via the built-in dashboard at `http://localhost:8080`.
+
+For more details on manual Docker setup, see `references/powersync-service.md`.
+
+### Path 4: Self-Hosted — CLI with Docker
+
+The CLI manages the Docker Compose stack for local development. Load `references/powersync-cli.md` for full CLI reference.
+
+1. **Install the CLI and scaffold:**
+   ```bash
+   npm install -g powersync
+   powersync init self-hosted
+   ```
+
+2. **Read the scaffolded `powersync/service.yaml`**, then prompt the user for connection details. If using `--database external`, the user needs to provide their source database URI. Otherwise the CLI provisions a local Postgres in Docker. See `references/powersync-service.md` for the YAML structure (`replication.connections`, `storage`, `client_auth`, `api.tokens`).
+
+3. **Configure and start the Docker stack:**
+   ```bash
+   powersync docker configure
+   # Use --database external if connecting to an existing database
+   # Use --storage external if using an existing storage database
+   powersync docker start
+   ```
+
+4. **Verify and generate tokens:**
+   ```bash
+   powersync status
+   powersync generate schema --output=ts --output-path=./schema.ts
+   powersync generate token --subject=user-test-1
+   ```
+
+For Docker stop/reset/cleanup commands, see `references/powersync-cli.md` → Docker section.
+
 ## What to Load for Your Task
 
 | Task | Load these files |
 |------|-----------------|
-| New project setup | See SDK Reference Files below for your platform |
+| New project setup | `references/powersync-cli.md` + `references/powersync-service.md` + `references/sync-config.md` + SDK files for your platform (see below) |
 | Handling file uploads / attachments | `references/attachments.md` |
 | Setting up PowerSync with Supabase (database, auth, fetchCredentials) | `references/supabase-auth.md` |
 | Debugging sync / connection issues | `references/powersync-debug.md` |
 | Writing or migrating sync config | `references/sync-config.md` |
-| Configuring the service / self-hosting | `references/powersync-service.md` |
-| Using the PowerSync CLI | `references/powersync-cli.md` |
+| Configuring the service / self-hosting | `references/powersync-service.md` + `references/powersync-cli.md` |
+| Using the PowerSync CLI | `references/powersync-cli.md` + `references/sync-config.md` |
 | Understanding the overall architecture | This file is sufficient; see `references/powersync-overview.md` for deep links |
 
 ## SDK Reference Files

--- a/skills/powersync/SKILL.md
+++ b/skills/powersync/SKILL.md
@@ -50,17 +50,162 @@ flowchart LR
 
 Key rule: **client writes never go through PowerSync** — they go directly from the app's upload queue to your backend API. PowerSync only handles the read/sync path.
 
+## Getting Started — PowerSync Service Setup
+
+When setting up the PowerSync Service, ask the user two questions if the answers aren't clear from context:
+1. **Cloud or Self-hosted?** — PowerSync Cloud (managed) or self-hosted (run your own Docker instance)?
+2. **Dashboard or CLI?** — For Cloud: set up via the PowerSync Dashboard UI, or via the PowerSync CLI? For Self-hosted: manual Docker setup, or use the CLI's Docker integration?
+
+Then follow the matching path below. For all paths, also load `references/powersync-service.md` and `references/sync-config.md`.
+
+### Path 1: Cloud — Dashboard Setup
+
+No CLI needed. The user does everything through the [PowerSync Dashboard](https://dashboard.powersync.com).
+
+Guide the user through these steps:
+
+1. **Sign up and create a project** — the user needs a PowerSync account at https://dashboard.powersync.com. Once signed in, they must create a project before they can create an instance.
+2. **Create a PowerSync instance** — inside the project, create a new instance.
+3. **Connect the source database** — in the instance settings, add the database connection. The user needs to provide:
+   - Database type (Postgres, MongoDB, MySQL, etc.)
+   - Connection URI or host/port/database/username/password
+   - The database must have replication enabled — see `references/powersync-service.md` → Source Database Setup for the SQL commands the user needs to run.
+4. **Configure sync rules** — in the instance's Sync Config editor, write Sync Streams that define what data each user receives. Must use `config: edition: 3`. See `references/sync-config.md` for the format.
+5. **Enable client authentication** — in the instance's "Client Auth" section, configure JWT verification (JWKS URI, Supabase Auth, etc.). For development, enable "Development Tokens" in this section.
+6. **Get the instance URL** — copy the instance URL from the dashboard. The app's `fetchCredentials()` needs this as the PowerSync endpoint.
+
+**IMPORTANT:** All steps must be completed. If any are missing, the app will be stuck on "Syncing..." with no data.
+
+### Path 2: Cloud — CLI Setup
+
+Load `references/powersync-cli.md` for full CLI reference.
+
+**What to ask the user before starting:**
+- Do they have a PowerSync account? If not, direct them to https://dashboard.powersync.com to sign up.
+- Have they created a project on the dashboard? If not, they need to create one first at https://dashboard.powersync.com (a project is required before creating an instance).
+- Do they have an existing instance, or should we create a new one?
+
+#### New Cloud Instance
+
+1. **Install and authenticate:**
+   ```bash
+   npm install -g powersync
+   powersync login
+   ```
+   `powersync login` opens a browser for the user to create/paste a personal access token (PAT). If they don't have one: https://dashboard.powersync.com/account/access-tokens
+
+2. **Scaffold config files:**
+   ```bash
+   powersync init cloud
+   ```
+   This creates `powersync/service.yaml` and `powersync/sync-config.yaml` with template values.
+
+3. **Read the scaffolded files**, then prompt the user for their database connection details and edit the files:
+   - `powersync/service.yaml` — fill in `replication.connections` with database type, host, port, database name, username, and password. For Cloud, use `password: secret: !env PS_DATABASE_PASSWORD` for credentials. See `references/powersync-service.md` for the correct YAML structure.
+   - `powersync/sync-config.yaml` — must start with `config: edition: 3`, then define `streams:`. Write Sync Streams based on the app's tables. See `references/sync-config.md`.
+
+4. **Ask the user for their project ID**, then create the instance and deploy:
+   ```bash
+   powersync link cloud --create --project-id=<project-id>
+   # Add --org-id=<org-id> only if their token has access to multiple orgs
+   powersync validate
+   powersync deploy
+   ```
+   The user can find their project ID on the PowerSync Dashboard under their project settings or by running `powersync fetch instances`.
+
+5. **Set up the source database** — the user must configure their database for replication. See `references/powersync-service.md` → Source Database Setup for the SQL commands. For Supabase, logical replication is already enabled but the user still needs to create the publication via the Supabase SQL Editor.
+
+6. **Generate a dev token** for testing:
+   ```bash
+   powersync generate token --subject=user-test-1
+   ```
+   Use this token in the app's `fetchCredentials()` during development.
+
+7. **Verify:** `powersync status` — confirm the instance is connected and replicating.
+
+#### Existing Cloud Instance
+
+**Ask the user for their project ID and instance ID**, then pull the config:
+```bash
+powersync login
+powersync pull instance --project-id=<project-id> --instance-id=<instance-id>
+# Add --org-id=<org-id> only if token has multiple orgs
+```
+The user can find these IDs on the PowerSync Dashboard or by running `powersync fetch instances`.
+
+**WARNING:** `powersync pull instance` silently overwrites local `service.yaml` and `sync-config.yaml`. Do not run it if there are uncommitted local changes to those files.
+
+After pulling, edit files as needed, then:
+```bash
+powersync validate
+powersync deploy
+```
+
+### Path 3: Self-Hosted — Manual Docker Setup
+
+No CLI needed. The user runs Docker directly with the PowerSync Service image.
+
+1. **Set up the source database** — see `references/powersync-service.md` → Source Database Setup.
+
+2. **Create the config file** — create a `config.yaml` with the correct structure. See `references/powersync-service.md` → Complete service.yaml Example. Key sections:
+   - `replication.connections` — the database connection (**must** be nested here, not at root level)
+   - `storage` — bucket storage database (MongoDB or Postgres, separate from source DB)
+   - `client_auth` — JWT verification settings
+   - `api.tokens` — API key for management access
+
+3. **Run the Docker container:**
+   ```bash
+   docker run \
+     -p 8080:80 \
+     -e POWERSYNC_CONFIG_B64="$(base64 -i ./config.yaml)" \
+     --network my-local-dev-network \
+     --name my-powersync journeyapps/powersync-service:latest
+   ```
+
+4. **Create the sync config** — write sync rules (see `references/sync-config.md`) either inline in `config.yaml` or via the built-in dashboard at `http://localhost:8080`.
+
+For more details on manual Docker setup, see `references/powersync-service.md`.
+
+### Path 4: Self-Hosted — CLI with Docker
+
+The CLI manages the Docker Compose stack for local development. Load `references/powersync-cli.md` for full CLI reference.
+
+1. **Install the CLI and scaffold:**
+   ```bash
+   npm install -g powersync
+   powersync init self-hosted
+   ```
+
+2. **Read the scaffolded `powersync/service.yaml`**, then prompt the user for connection details. If using `--database external`, the user needs to provide their source database URI. Otherwise the CLI provisions a local Postgres in Docker. See `references/powersync-service.md` for the YAML structure (`replication.connections`, `storage`, `client_auth`, `api.tokens`).
+
+3. **Configure and start the Docker stack:**
+   ```bash
+   powersync docker configure
+   # Use --database external if connecting to an existing database
+   # Use --storage external if using an existing storage database
+   powersync docker start
+   ```
+
+4. **Verify and generate tokens:**
+   ```bash
+   powersync status
+   powersync generate schema --output=ts --output-path=./schema.ts
+   powersync generate token --subject=user-test-1
+   ```
+
+For Docker stop/reset/cleanup commands, see `references/powersync-cli.md` → Docker section.
+
 ## What to Load for Your Task
 
 | Task | Load these files |
 |------|-----------------|
-| New project setup | See SDK Reference Files below for your platform |
+| New project setup | `references/powersync-cli.md` + `references/powersync-service.md` + `references/sync-config.md` + SDK files for your platform (see below) |
 | Handling file uploads / attachments | `references/attachments.md` |
 | Setting up PowerSync with Supabase (database, auth, fetchCredentials) | `references/supabase-auth.md` |
 | Debugging sync / connection issues | `references/powersync-debug.md` |
 | Writing or migrating sync config | `references/sync-config.md` |
-| Configuring the service / self-hosting | `references/powersync-service.md` |
-| Using the PowerSync CLI | `references/powersync-cli.md` |
+| Configuring the service / self-hosting | `references/powersync-service.md` + `references/powersync-cli.md` |
+| Using the PowerSync CLI | `references/powersync-cli.md` + `references/sync-config.md` |
 | Understanding the overall architecture | This file is sufficient; see `references/powersync-overview.md` for deep links |
 
 ## SDK Reference Files

--- a/skills/powersync/references/powersync-cli.md
+++ b/skills/powersync/references/powersync-cli.md
@@ -7,7 +7,7 @@ metadata:
 
 # PowerSync CLI
 
-The PowerSync CLI manages Cloud and self-hosted PowerSync instances from the command line. It supports local config management, schema generation, development token generation, deployment, and more.
+The PowerSync CLI manages Cloud and self-hosted PowerSync instances from the command line. It supports local config management, schema generation, development token generation, deployment, and more. See [this](https://docs.powersync.com/tools/cli) for any information not supplied in this document about the CLI.
 
 ## Installation
 ```bash
@@ -102,32 +102,98 @@ password: secret_ref: default_password
 
 ## Cloud Usage
 
-### New Instance
+### New Cloud Instance
+
+**Information the agent must collect from the user before proceeding:**
+- PowerSync account (if they don't have one, direct to https://dashboard.powersync.com to sign up)
+- A project on the dashboard (required before creating an instance — if they don't have one, they must create one at https://dashboard.powersync.com first)
+- Project ID (find on dashboard or via `powersync fetch instances` after login)
+- Org ID (only if their token covers multiple organizations)
+- Database connection details (type, host, port, database name, username, password)
+
+**Step-by-step:**
 
 ```bash
-powersync login
-powersync init cloud                          # scaffold powersync/ directory
-# Edit powersync/service.yaml and sync config
-powersync link cloud --create --project-id=<project-id>   # creates instance + writes cli.yaml
+# 1. Authenticate
+powersync login                               # opens browser for PAT
+
+# 2. Scaffold config files
+powersync init cloud                          # creates powersync/ with service.yaml and sync-config.yaml
+```
+
+**After `powersync init cloud`:** Read the generated `powersync/service.yaml` and `powersync/sync-config.yaml`. These contain placeholder values. Prompt the user for their database connection details and edit the files before continuing.
+
+```bash
+# 3. Create instance and deploy
+powersync link cloud --create --project-id=<project-id>
 # Add --org-id=<org-id> only if token has multiple orgs
 powersync validate
 powersync deploy
 ```
 
-### Existing Instance
+#### Cloud service.yaml Example
+
+The database connection **must** be nested under `replication.connections` — not at the root level:
+
+```yaml
+# powersync/service.yaml — Cloud
+replication:
+  connections:
+    - type: postgresql
+      hostname: !env PS_DATABASE_HOST
+      port: 5432
+      database: !env PS_DATABASE_NAME
+      username: !env PS_DATABASE_USER
+      password:
+        secret: !env PS_DATABASE_PASSWORD   # stored as Cloud secret on first deploy
+      sslmode: verify-full
+```
+
+For the full `service.yaml` schema, see `references/powersync-service.md`.
+
+#### Cloud sync-config.yaml Example
+
+The `sync-config.yaml` **must** start with a `config: edition: 3` top-level wrapper:
+
+```yaml
+# powersync/sync-config.yaml — Cloud
+config:
+  edition: 3
+
+streams:
+  my_data:
+    auto_subscribe: true
+    query: SELECT * FROM my_table WHERE user_id = auth.user_id()
+```
+
+For the full sync config reference, see `references/sync-config.md`.
+
+### Existing Cloud Instance
+
+**Information the agent must collect from the user:**
+- Project ID
+- Instance ID
+- Org ID (only if token covers multiple orgs)
+
+The user can find these on the PowerSync Dashboard or by running `powersync fetch instances` after `powersync login`.
 
 ```bash
 powersync login
 powersync pull instance --project-id=<project-id> --instance-id=<instance-id>
-# Creates powersync/, writes cli.yaml, downloads service.yaml and sync-config.yaml
 # Add --org-id=<org-id> only if token has multiple orgs
+```
 
-# Edit YAML files as needed
+This creates `powersync/`, writes `cli.yaml`, and downloads `service.yaml` and `sync-config.yaml`.
+
+If the directory is already linked, `powersync pull instance` (no IDs needed) refreshes local config from the cloud.
+
+**WARNING:** `powersync pull instance` **silently overwrites** your local `service.yaml` and `sync-config.yaml` with the remote version. Any hand-crafted or uncommitted local changes will be lost without warning or merge prompt. Always commit or back up local config files before running `pull instance`.
+
+After pulling, edit files as needed, then:
+```bash
 powersync validate
 powersync deploy
 ```
-
-If the directory is already linked, `powersync pull instance` (no IDs needed) refreshes local config from the cloud.
 
 ### Deploy Commands
 
@@ -151,22 +217,65 @@ powersync generate token
 
 ## Self-Hosted Usage
 
+### Self-Hosted with CLI + Docker (Recommended for Local Development)
+
+The CLI manages a full Docker Compose stack for local development and testing.
+
+**Prerequisites:** Docker and Docker Compose V2 (2.20.3+).
+
+**Information the agent may need from the user:**
+- If using `--database external`: the source database URI (set as `PS_DATA_SOURCE_URI`)
+- If using `--storage external`: the storage database URI (set as `PS_STORAGE_SOURCE_URI`)
+- If using the default options: no user input needed — the CLI provisions local Postgres for both
+
+**Step-by-step:**
+
 ```bash
-powersync init self-hosted     # scaffold config template into powersync/
-# Edit YAML files (include api.tokens for API key auth in service.yaml)
+# 1. Scaffold config
+powersync init self-hosted                    # creates powersync/ with service.yaml template
 
-# Once your instance is deployed and reachable:
-powersync link self-hosted --api-url=https://your-powersync.example.com
-# Sets api_key in cli.yaml — use !env PS_ADMIN_TOKEN or set PS_ADMIN_TOKEN env var
+# 2. Configure Docker stack
+powersync docker configure
+# Use --database external to connect to an existing source database
+# Use --storage external to use an existing storage database
 
-powersync generate schema
-powersync generate token
-powersync status
+# 3. Start the stack
+powersync docker start                        # docker compose up -d --wait
 ```
 
-`--api-url` is the URL your running PowerSync instance is exposed from (configured by your deployment — Docker, Coolify, etc.).
+**After `powersync init self-hosted`:** Read the generated `powersync/service.yaml`. If the user is connecting to an external database, prompt them for the connection URI and update the file. The `powersync docker configure` command will merge Docker-specific settings into `service.yaml` and write `cli.yaml`.
 
-Supported self-hosted commands: `status`, `generate schema`, `generate token`, `validate`, `fetch instances`. The CLI does not provision or deploy to a remote server; use Docker for local development.
+```bash
+# 4. Verify and use the instance
+powersync status
+powersync validate
+powersync generate schema --output=ts --output-path=./schema.ts
+powersync generate token --subject=user-test-1
+```
+
+### Self-Hosted — Linking to an Existing Instance
+
+For self-hosted instances already running (not managed by the CLI), the CLI can link to them for schema generation, token generation, and status checks.
+
+**Information the agent must collect from the user:**
+- API URL of the running PowerSync instance
+- API token (must match a token configured in the instance's `api.tokens` setting)
+
+```bash
+powersync init self-hosted                    # scaffold config template
+# Edit powersync/service.yaml (include api.tokens for API key auth)
+
+powersync link self-hosted --api-url=https://your-powersync.example.com
+# Set PS_ADMIN_TOKEN env var to match the instance's api.tokens value
+
+powersync status
+powersync generate schema
+powersync generate token
+```
+
+`--api-url` is the URL the running PowerSync instance is exposed from (configured by your deployment — Docker, Coolify, etc.).
+
+Supported self-hosted commands: `status`, `generate schema`, `generate token`, `validate`, `fetch instances`. The CLI does **not** create, deploy to, or pull config from a remote self-hosted server — you manage the server and its config yourself.
 
 ## Supplying Instance Info Without Linking
 
@@ -252,27 +361,9 @@ Contents of `powersync/`:
 - `service.yaml` — service configuration (name, region, replication connection, auth)
 - `sync-config.yaml` — sync rules / sync streams config
 
-## Docker (Self-Hosted Local Stack)
+## Docker Commands Reference
 
-`powersync docker` runs a self-hosted PowerSync stack with Docker Compose for local development and testing.
-
-**Prerequisites:** Docker and Docker Compose V2 (2.20.3+).
-
-### Workflow
-
-```bash
-# 1. Scaffold config and configure Docker stack
-powersync init self-hosted
-powersync docker configure        # links to local API automatically; creates powersync/docker/
-
-# 2. Start the stack
-powersync docker start            # docker compose up -d --wait
-
-# 3. Use the local instance
-powersync status
-powersync validate
-powersync generate schema --output=ts --output-path=./schema.ts
-```
+For the full Docker setup workflow, see [Self-Hosted with CLI + Docker](#self-hosted-with-cli--docker-recommended-for-local-development) above.
 
 ### Stop and Reset
 

--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -51,10 +51,37 @@ There are three configuration methods available:
 #### Environment variable substitution
 Use !env PS_VARIABLE_NAME in YAML for config values.
 
+### Complete service.yaml Example
+
+Below is a minimal but complete `service.yaml` for a self-hosted instance. Pay close attention to the YAML nesting — in particular, the database connection **must** be under `replication.connections`, not a top-level `connections` key.
+
+```yaml
+# powersync/service.yaml — self-hosted
+replication:
+  connections:
+    - type: postgresql
+      uri: !env PS_DATA_SOURCE_URI   # e.g. postgresql://user:pass@host:5432/db
+
+storage:
+  type: mongodb
+  uri: !env PS_STORAGE_URI           # e.g. mongodb://localhost:27017/powersync
+
+# Client auth — required before `powersync generate token` works
+client_auth:
+  jwks_uri: !env PS_JWKS_URI
+
+# API key for CLI access (matches PS_ADMIN_TOKEN)
+api:
+  tokens:
+    - !env PS_ADMIN_TOKEN
+```
+
 ### Replication connections
 
+**IMPORTANT:** The database connection **must** be nested under `replication.connections` — not a top-level `connections` key. Placing it elsewhere (e.g. `connections:` at the root) will cause a "No connection found in config" error.
+
 Only one source database connection is supported per instance. Example:
-```
+```yaml
 replication:
   connections:
     - type: postgresql
@@ -78,7 +105,20 @@ There are various options when configuring client authentication on a PowerSync 
 
 ## PowerSync Cloud Setup
 
-See [PowerSync Cloud Instances](https://docs.powersync.com/configuration/powersync-service/cloud-instances.md) for step-by-step instructions on how to configure PowerSync Cloud instance on the [PowerSync Dashboard](https://dashboard.powersync.com).
+PowerSync Cloud can be set up via the **Dashboard** (UI) or the **CLI**. Both paths require the same four steps. **If any step is missing, the app will be stuck on "Syncing..." with no data.**
+
+| Step | Dashboard | CLI |
+|------|-----------|-----|
+| 1. Create instance | Dashboard → New Instance | `powersync link cloud --create --project-id=<id>` |
+| 2. Connect source DB | Instance Settings → Database | Edit `powersync/service.yaml` → `replication.connections`, then `powersync deploy` |
+| 3. Deploy sync config | Instance → Sync Config editor | Edit `powersync/sync-config.yaml`, then `powersync deploy sync-config` |
+| 4. Enable client auth | Instance → Client Auth section | Edit `powersync/service.yaml` → `client_auth`, then `powersync deploy service-config` |
+
+**IMPORTANT:** All four steps must be completed. The most common cause of an app stuck on "Syncing..." is a missing or misconfigured step above — typically the database connection or sync config not being deployed.
+
+For full CLI setup workflow, see `references/powersync-cli.md` → Cloud Usage.
+
+See [PowerSync Cloud Instances](https://docs.powersync.com/configuration/powersync-service/cloud-instances.md) for detailed dashboard step-by-step instructions.
 
 ## Source Database Setup
 

--- a/skills/powersync/references/supabase-auth.md
+++ b/skills/powersync/references/supabase-auth.md
@@ -95,9 +95,44 @@ client_auth:
 
 Get the secret from Supabase → Project Settings → JWT. Use `!env` to avoid hardcoding secrets.
 
-### Manual JWKS (non-standard / local Supabase)
+### Local Supabase (`supabase start`)
 
-Use when `supabase: true` cannot auto-detect the project (e.g. self-hosted Supabase or local Docker):
+**IMPORTANT:** Local Supabase (via `supabase start`) uses **ES256 asymmetric JWT signing keys**, not the legacy HS256 shared secret. This means:
+
+- `supabase: true` alone **will not work** — it cannot auto-detect a local project from the connection string.
+- `supabase: true` + `supabase_jwt_secret` **will not work** — it registers an HS256 key, but local Supabase issues ES256 tokens with a `kid` that doesn't match.
+- You **must** use manual JWKS pointing to the local Supabase JWKS endpoint.
+
+The error you'll see if misconfigured:
+```
+PSYNC_S2101: Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID
+```
+With details showing: `Known keys: <kid: *, kty: oct, alg: HS256>` but the token has `alg: ES256` with a specific `kid`.
+
+**Correct config for local Supabase:**
+
+```yaml
+client_auth:
+  jwks_uri: http://host.docker.internal:54321/auth/v1/.well-known/jwks.json
+  audience:
+    - authenticated
+  block_local_jwks: false
+```
+
+Key details:
+- Use `host.docker.internal` (not `localhost`) because this URI is resolved **from inside the PowerSync Docker container**.
+- `block_local_jwks: false` is required because `host.docker.internal` resolves to a local/private IP, which PowerSync blocks by default.
+- The well-known local Supabase JWT secret (`super-secret-jwt-token-with-at-least-32-characters-long`) is **not used** for token signing in newer Supabase versions — it's only used for the service role key and anon key.
+
+You can verify your local Supabase is using ES256 by checking:
+```bash
+curl -s http://127.0.0.1:54321/auth/v1/.well-known/jwks.json
+# Returns: {"keys":[{"alg":"ES256","crv":"P-256","kty":"EC",...}]}
+```
+
+### Manual JWKS (other non-standard connections)
+
+Use when `supabase: true` cannot auto-detect the project (e.g. self-hosted Supabase, custom auth proxy):
 
 ```yaml
 client_auth:
@@ -197,14 +232,16 @@ val connector = SupabaseConnector(
 
 ### `PSYNC_S2101` — Could not find an appropriate key in the keystore
 
-PowerSync cannot verify the JWT signature.
+PowerSync cannot verify the JWT signature. Check the error logs for `Known keys` and `tokenDetails` to diagnose the mismatch.
 
-| Cause | Solution |
-|-------|---------|
-| Incomplete Supabase key migration | Complete the "Rotate to asymmetric JWTs" step in the [Supabase migration guide](https://supabase.com/blog/jwt-signing-keys#start-using-asymmetric-jwts-today). |
-| Stale tokens after migration | Have users sign out and back in to receive new tokens. |
-| Auto-detection failed | PowerSync couldn't detect your Supabase project from the connection string. Use manual JWKS config. |
-| Wrong JWT secret | For legacy HS256 keys, verify the secret matches Supabase → Project Settings → JWT. |
+| Cause | Symptom | Solution |
+|-------|---------|---------|
+| **Local Supabase with `supabase_jwt_secret`** | Known keys show `HS256` but token uses `ES256` with a specific `kid` | Local Supabase uses ES256 asymmetric keys. Switch to manual JWKS config — see "Local Supabase" section above. |
+| Incomplete Supabase key migration | Token `alg` doesn't match keystore | Complete the "Rotate to asymmetric JWTs" step in the [Supabase migration guide](https://supabase.com/blog/jwt-signing-keys#start-using-asymmetric-jwts-today). |
+| Stale tokens after migration | Old tokens fail, new logins work | Have users sign out and back in to receive new tokens. |
+| Auto-detection failed | `supabase: true` but no keys registered | PowerSync couldn't detect your Supabase project from the connection string. Use manual JWKS config. |
+| Wrong JWT secret | HS256 verification fails | For legacy HS256 keys, verify the secret matches Supabase → Project Settings → JWT. |
+| `block_local_jwks` blocking JWKS fetch | JWKS URI resolves to private IP, keys never fetched | Set `block_local_jwks: false` for local development. |
 
 ### `PSYNC_S2105` — JWT payload is missing a required claim "aud"
 

--- a/skills/powersync/references/supabase-auth.md
+++ b/skills/powersync/references/supabase-auth.md
@@ -113,6 +113,9 @@ With details showing: `Known keys: <kid: *, kty: oct, alg: HS256>` but the token
 
 ```yaml
 client_auth:
+  # Use host.docker.internal to reach the host machine from inside the PowerSync Docker container.
+  # Alternatively, use the Supabase Kong container name (e.g. supabase_kong_<project-id>)
+  # if both are on the same Docker network.
   jwks_uri: http://host.docker.internal:54321/auth/v1/.well-known/jwks.json
   audience:
     - authenticated
@@ -120,7 +123,7 @@ client_auth:
 ```
 
 Key details:
-- Use `host.docker.internal` (not `localhost`) because this URI is resolved **from inside the PowerSync Docker container**.
+- Use `host.docker.internal` or the Supabase container name (not `localhost`) because this URI is resolved **from inside the PowerSync Docker container**.
 - `block_local_jwks: false` is required because `host.docker.internal` resolves to a local/private IP, which PowerSync blocks by default.
 - The well-known local Supabase JWT secret (`super-secret-jwt-token-with-at-least-32-characters-long`) is **not used** for token signing in newer Supabase versions — it's only used for the service role key and anon key.
 

--- a/skills/powersync/references/sync-config.md
+++ b/skills/powersync/references/sync-config.md
@@ -36,6 +36,21 @@ There are minimum SDK requirements when using Sync Streams in an application. Se
 IMPORTANT
 Client applications using a lower version than the `Rust Client Default` should make sure to enable the Rust Sync Client to use Sync Streams. 
 
+## sync-config.yaml File Format
+
+**IMPORTANT:** The `sync-config.yaml` file **must** begin with a top-level `config:` block specifying the edition. Without this wrapper, the PowerSync Service will reject the config. This is the most common deployment error — do not omit it.
+
+```yaml
+# powersync/sync-config.yaml — required structure
+config:
+  edition: 3        # <-- REQUIRED top-level wrapper
+
+streams:
+  my_data:
+    auto_subscribe: true
+    query: SELECT * FROM my_table WHERE user_id = auth.user_id()
+```
+
 ## Structure
 ```yaml
 config:
@@ -375,7 +390,7 @@ Reference these when the standard patterns don't cover your use case:
 | [Partitioned Tables](https://docs.powersync.com/sync/advanced/partitioned-tables.md) | Sync from Postgres partitioned tables |
 | [Sharded Databases](https://docs.powersync.com/sync/advanced/sharded-databases.md) | Source data from multiple database shards |
 
-# Sync Rules
+# Sync Rules (Legacy, use Sync Streams for new applications)
 
 Sync rules define how data is partitioned into buckets and distributed to clients. This is considered legacy, however will still be supported. For the best experience use [sync-streams](#sync-streams).
 


### PR DESCRIPTION
- Add 4 clear setup paths (Cloud Dashboard, Cloud CLI, Self-hosted Docker, Self-hosted CLI+Docker) to `SKILL.md` and `AGENTS.md`
- Fix undocumented pitfalls: `replication.connections` nesting, `config: edition: 3` requirement, `pull instance` overwrite behavior
- Add explicit prompts for agents to collect user info (project ID, instance ID, DB credentials) before running CLI commands
- Add PowerSync account/project creation as prerequisite step for Cloud paths