### PR TITLE
Add continuous-use guardrails

### DIFF
--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -16,6 +16,39 @@ Use this skill to onboard a project onto PowerSync without trial-and-error. Trea
 
 If the user wants a shortcut, they must **say so explicitly** (e.g. “I can’t use the CLI, give dashboard steps only”).
 
+## Continuous Use & Guardrails (existing projects)
+
+The onboarding playbook below assumes a fresh project. When the project is **already set up**, the rules below take precedence. Continuous-use sessions on existing PowerSync projects are where agents do the most damage — assume nothing about the linked instance, scope of changes, or environment.
+
+### Default scope: sync streams only
+
+On an existing project, the default scope of changes is **`sync-config.yaml` (sync streams) only**. Do not touch `service.yaml` (replication connections, storage, ports, auth, instance name) or `cli.yaml` unless the user has explicitly asked for service or infra changes in this conversation. Sync stream edits are recoverable by re-deploying; service-config or wrong-instance link changes can break replication or take down a production app.
+
+If the user’s request seems to require a service-config change, **stop and confirm** before editing `service.yaml`. Do not silently broaden scope.
+
+### Confirm the target instance before any mutating command
+
+Before running any command that mutates Cloud state — `powersync deploy`, `powersync deploy service-config`, `powersync deploy sync-config`, `powersync destroy`, `powersync stop`, `powersync link cloud --create`, or `powersync pull instance` — confirm:
+
+1. **Which instance** the command will hit. Run `powersync fetch instances` or read `powersync/cli.yaml` and tell the user the instance id and project before proceeding.
+2. **Whether that instance is production.** If the user has not stated which instances are safe to touch, ask. Never deploy to an instance you have not been authorized for in this session or in saved project memory (see below).
+3. For `destroy`, `stop`, and any production-tagged instance: surface the command and the target, then wait for explicit confirmation. Treat “yes go ahead” for one command as authorization for that command only — not a blanket approval for future destructive actions.
+
+`powersync pull instance` silently overwrites local `service.yaml` and `sync-config.yaml`. Back up first; never run it after local edits unless the user confirms losing those edits is acceptable.
+
+### Save and reuse project memory
+
+Many of the inputs above are stable across sessions. If your harness has a project memory or persistent notes file, **record these once and reuse them** so the user is not asked the same questions every session and so you do not re-discover paths each turn. Save:
+
+- **CLI install path / invocation** — e.g. `powersync` on PATH, `npx powersync@<version>`, or a project-local install — whatever resolves in this repo. Avoids reinstalling or hunting for the binary.
+- **Config directory and sync-config path** — e.g. `powersync/sync-config.yaml`, or a non-default `--directory`. Avoids re-globbing.
+- **Authorized instances and their environment** — e.g. “`<instance-id-A>` = dev (safe to deploy), `<instance-id-B>` = prod (ask before any deploy/destroy/stop)”. Cite this list before running mutating commands.
+- **Allowed scope of changes** — e.g. “sync-config only” vs. “sync-config + service-config authorized”. Default to sync-config only until the user broadens it.
+
+Before acting on a saved entry that names a specific instance, file path, or CLI binary, verify it still matches reality (file exists, instance still in `powersync fetch instances`). If it has changed, update the memory rather than acting on a stale value. If saved memory says “prod = do not touch” and the user now asks you to deploy to prod, treat that as a scope expansion and confirm explicitly before proceeding.
+
+If your harness has no persistent memory, ask the user the relevant questions at session start and keep the answers in the active conversation.
+
 
 ## Always Use the PowerSync CLI
 

--- a/skills/powersync/SKILL.md
+++ b/skills/powersync/SKILL.md
@@ -23,6 +23,9 @@ Use this skill to onboard a project onto PowerSync without trial-and-error. Trea
 - **Backend before frontend.** Deploy sync config and verify the service before writing app code.
 - **Sync Streams for new projects.** Sync Rules are legacy.
 - **Persist credentials immediately.** Write all URLs and keys to `.env` as soon as they are available.
+- **Default scope on existing projects: sync-config only.** Do not edit `service.yaml` or `cli.yaml` unless the user explicitly authorized service/infra changes in this conversation.
+- **Confirm the target instance before any mutating command** (`deploy`, `destroy`, `stop`, `link --create`, `pull instance`). Never deploy to an instance you have not been authorized for. Treat production as off-limits unless explicitly approved.
+- **Use project memory.** If your harness supports it, persist the CLI invocation, sync-config path, authorized instance ids + environment (dev/staging/prod), and allowed scope of changes. Verify saved values still match reality before acting on them. See `AGENTS.md` § "Continuous Use & Guardrails".
 
 ## What to Load for Your Task
 

--- a/skills/powersync/references/powersync-cli.md
+++ b/skills/powersync/references/powersync-cli.md
@@ -39,6 +39,28 @@ Use these defaults unless the user explicitly wants something else:
 - Sync config validation or deploy failures often mean `powersync/sync-config.yaml` is missing the top-level `config: edition: 3` wrapper.
 - `powersync pull instance` silently overwrites local `service.yaml` and `sync-config.yaml`.
 
+## Mutating Commands — Confirm Before Running
+
+These commands change Cloud state or local config. On an existing project, do not run them without confirming the target instance and that the user has authorized the change.
+
+| Command | Effect | Required check |
+|---------|--------|----------------|
+| `powersync deploy` | Pushes `service.yaml` + `sync-config.yaml` to the linked instance | Confirm instance id and that user authorized deploying both files. If only sync streams changed, prefer `powersync deploy sync-config`. |
+| `powersync deploy service-config` | Replaces service config (replication, storage, auth) on the linked instance | Service-config edits are out-of-scope by default — get explicit user authorization in this conversation before running. |
+| `powersync deploy sync-config` | Replaces sync config on the linked instance | Confirm instance id + environment (dev/staging/prod) before running. Never deploy to a production instance the user has not approved. |
+| `powersync destroy --confirm=yes` | Permanently destroys the linked Cloud instance | Always require explicit, in-conversation confirmation naming the instance. Treat as one-shot authorization. |
+| `powersync stop --confirm=yes` | Stops the linked Cloud instance (clients lose sync) | Same as `destroy` — confirm instance and that the user accepts downtime. |
+| `powersync link cloud --create` | Creates a new Cloud instance | Only during initial bootstrap. Do not run on a project that already has a linked instance unless the user explicitly wants a second one. |
+| `powersync pull instance` | Overwrites local `service.yaml` and `sync-config.yaml` from the remote | Back up local files first. Do not run after local edits unless the user accepts losing them. |
+
+**How to confirm the target instance.** Before any command in the table:
+
+1. Run `powersync fetch instances` (or read `powersync/cli.yaml`) and tell the user the instance id, project id, and — if known from project memory — its environment.
+2. If the environment is production or unknown, ask before proceeding. Do not assume "linked" means "safe."
+3. One approval covers one command. Re-confirm for the next mutating command.
+
+**Default scope on existing projects.** Only edit and deploy `sync-config.yaml`. Leave `service.yaml` and `cli.yaml` alone unless the user has authorized service/infra changes in this conversation. See `AGENTS.md` § "Continuous Use & Guardrails".
+
 ## Recommended Cloud Sequence
 
 For the common Cloud path, use this order:
@@ -508,6 +530,8 @@ powersync deploy sync-config
 ```
 
 ## Common Commands
+
+> **Mutating commands** (`deploy`, `destroy`, `stop`, `link --create`, `pull instance`) require an instance + scope check before running — see "Mutating Commands — Confirm Before Running" above.
 
 | Command | Description |
 |---------|-------------|


### PR DESCRIPTION
The current skill works great for bootstrapping but can be unsafe for existing projects. Agents will deploy to whatever instance is linked (could be production), edit `service.yaml` without being asked, and rediscover the CLI path every session.

- Add "Continuous Use & Guardrails" section to `skills/powersync/AGENTS.md` covering default scope (sync-config only), instance confirmation before mutating commands, and project-memory persistence
- Mirror the rules as concise bullets in `skills/powersync/SKILL.md` Quick Rules
- Add "Mutating Commands - Confirm Before Running" table to `references/powersync-cli.md` with per-command checks for `deploy`, `deploy service-config`, `deploy sync-config`, `destroy`, `stop`, `link --create`, and `pull instance`
- Cross-reference the guardrails section from the Common Commands table