### PR TITLE
Rename operator references and compress AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 /temp-claude
 /powersync-workspace
 **/evals/
+skills/powersync-workspace

--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -15,7 +15,7 @@ If a sentence is ambiguous, default to the operator interpretation.
 
 | Do | Don’t |
 |----|--------|
-| Ask the operator for **Cloud vs self-hosted** and **which backend** if not stated | Ask which it is ( Supabase, Postgres, MSSQL, MYSQL MongoDB or self-hosted Docker) |
+| **Ask the operator** before doing anything: (1) **Cloud or self-hosted**, (2) **which database** (Supabase, Postgres, MongoDB, MySQL, MSSQL), and (3) **only if not Supabase**, whether they have a backend API or need to build one. Use the **PowerSync CLI** by default for all operations. | Assume any answer, pick a default (e.g. Supabase, Postgres, self-hosted Docker), skip a question, or ask about a backend API when the operator already chose Supabase (Supabase *is* the backend). Do not hand-write config files or use the dashboard unless the operator explicitly says they cannot use the CLI. |
 | Use the **PowerSync CLI** to scaffold, link (if cloud hosted), and deploy (`references/powersync-cli.md`) | Hand-write `service.yaml` / `sync-config.yaml` from scratch or invent compose files **unless** the operator explicitly says they cannot use the CLI |
 | **Stop and ask** when a step needs credentials or interactive Cloud login you cannot perform | Silently build an alternate stack (e.g. manual Docker) without operator confirmation |
 | Complete **backend readiness** (deployed sync config, auth, publication) **before** app code | Start React/client integration while sync is still unconfigured |

--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -2,129 +2,141 @@
 
 Use this skill to onboard a project onto PowerSync without trial-and-error. Treat this as a guided workflow first and a reference library second.
 
+## Terminology (read first)
+
+- **Operator** — the human directing this agent (whose request you are fulfilling). All "ask", "confirm", "tell" instructions in this skill refer to the operator unless they say otherwise.
+- **User** — an end-user of the operator's PowerSync app (JWT subjects, the row a sync stream filters by, the person calling `disconnectAndClear()`, attachments owners). Used only in the app-domain sense.
+
+If a sentence is ambiguous, default to the operator interpretation.
+
 ## Agent compliance (read first — non-negotiable)
 
 **Follow this file’s playbook in order.** Do not skip ahead, assume defaults, or substitute your own architecture to “save time.”
 
 | Do | Don’t |
 |----|--------|
-| Ask for **Cloud vs self-hosted** and **which backend** if the user did not say | Assume Supabase, assume Postgres, or pick self-hosted Docker without asking |
-| Use the **PowerSync CLI** to scaffold, link (if cloud hosted), and deploy (`references/powersync-cli.md`) | Hand-write `service.yaml` / `sync-config.yaml` from scratch or invent compose files **unless** the user explicitly says they cannot use the CLI |
-| **Stop and ask** when a step needs credentials or interactive Cloud login you cannot perform | Silently build an alternate stack (e.g. manual Docker) without user confirmation |
+| Ask the operator for **Cloud vs self-hosted** and **which backend** if not stated | Ask which it is ( Supabase, Postgres, MSSQL, MYSQL MongoDB or self-hosted Docker) |
+| Use the **PowerSync CLI** to scaffold, link (if cloud hosted), and deploy (`references/powersync-cli.md`) | Hand-write `service.yaml` / `sync-config.yaml` from scratch or invent compose files **unless** the operator explicitly says they cannot use the CLI |
+| **Stop and ask** when a step needs credentials or interactive Cloud login you cannot perform | Silently build an alternate stack (e.g. manual Docker) without operator confirmation |
 | Complete **backend readiness** (deployed sync config, auth, publication) **before** app code | Start React/client integration while sync is still unconfigured |
 | Use **Sync Streams** (`config: edition: 3`) for new projects | Generate legacy Sync Rules YAML for new projects |
 
-If the user wants a shortcut, they must **say so explicitly** (e.g. “I can’t use the CLI, give dashboard steps only”).
+Shortcut requested? Operator must say so explicitly (e.g. “no CLI, dashboard only”).
 
 ## Continuous Use & Guardrails (existing projects)
 
-The onboarding playbook below assumes a fresh project. When the project is **already set up**, the rules below take precedence. Continuous-use sessions on existing PowerSync projects are where agents do the most damage — assume nothing about the linked instance, scope of changes, or environment.
+The onboarding playbook below assumes a fresh project. On an **existing** project the rules in this section take precedence. Continuous-use sessions are where agents do the most damage — assume nothing about the linked instance, scope, or environment.
 
 ### Default scope: sync streams only
 
-On an existing project, the default scope of changes is **`sync-config.yaml` (sync streams) only**. Do not touch `service.yaml` (replication connections, storage, ports, auth, instance name) or `cli.yaml` unless the user has explicitly asked for service or infra changes in this conversation. Sync stream edits are recoverable by re-deploying; service-config or wrong-instance link changes can break replication or take down a production app.
-
-If the user’s request seems to require a service-config change, **stop and confirm** before editing `service.yaml`. Do not silently broaden scope.
+- Edit only `sync-config.yaml`.
+- `service.yaml` (replication, storage, ports, auth, instance name) and `cli.yaml`? Stop and get explicit operator authorization in this conversation before editing.
+- **Why:** sync-stream edits are recoverable by re-deploying; service-config or wrong-instance link changes can break replication or take down a production app.
 
 ### Confirm the target instance before any mutating command
 
-Before running any command that mutates Cloud state — `powersync deploy`, `powersync deploy service-config`, `powersync deploy sync-config`, `powersync destroy`, `powersync stop`, `powersync link cloud --create`, or `powersync pull instance` — confirm:
+Mutating commands: `powersync deploy`, `deploy service-config`, `deploy sync-config`, `destroy`, `stop`, `link cloud --create`, `pull instance`.
 
-1. **Which instance** the command will hit. Run `powersync fetch instances` or read `powersync/cli.yaml` and tell the user the instance id and project before proceeding.
-2. **Whether that instance is production.** If the user has not stated which instances are safe to touch, ask. Never deploy to an instance you have not been authorized for in this session or in saved project memory (see below).
-3. For `destroy`, `stop`, and any production-tagged instance: surface the command and the target, then wait for explicit confirmation. Treat “yes go ahead” for one command as authorization for that command only — not a blanket approval for future destructive actions.
+Before running any of them:
 
-`powersync pull instance` silently overwrites local `service.yaml` and `sync-config.yaml`. Back up first; never run it after local edits unless the user confirms losing those edits is acceptable.
+1. **Which instance?** Run `powersync fetch instances` or read `powersync/cli.yaml`; tell the operator the instance id + project.
+2. **Is it production?** If the operator has not said which instances are safe, ask. Do not deploy to an instance not authorized in this session or in saved project memory.
+3. `destroy`, `stop`, or any production-tagged instance → surface the command and target, wait for explicit go-ahead. One approval = one command, not a blanket pass.
+
+`powersync pull instance` silently overwrites local `service.yaml` + `sync-config.yaml`. Back up first; never run it after local edits unless the operator accepts losing them.
 
 ### Save and reuse project memory
 
-Many of the inputs above are stable across sessions. If your harness has a project memory or persistent notes file, **record these once and reuse them** so the user is not asked the same questions every session and so you do not re-discover paths each turn. Save:
+If your harness has a project memory or persistent notes file, record these once so the operator is not re-asked each session and you do not re-discover paths each turn:
 
-- **CLI install path / invocation** — e.g. `powersync` on PATH, `npx powersync@<version>`, or a project-local install — whatever resolves in this repo. Avoids reinstalling or hunting for the binary.
-- **Config directory and sync-config path** — e.g. `powersync/sync-config.yaml`, or a non-default `--directory`. Avoids re-globbing.
-- **Authorized instances and their environment** — e.g. “`<instance-id-A>` = dev (safe to deploy), `<instance-id-B>` = prod (ask before any deploy/destroy/stop)”. Cite this list before running mutating commands.
-- **Allowed scope of changes** — e.g. “sync-config only” vs. “sync-config + service-config authorized”. Default to sync-config only until the user broadens it.
+| What to save | Example | Why |
+|--------------|---------|-----|
+| CLI invocation | `powersync` on PATH, `npx powersync@<v>`, project-local install | Skip reinstall / binary hunt |
+| Config dir + sync-config path | `powersync/sync-config.yaml`, or non-default `--directory` | Skip re-globbing |
+| Authorized instances + env | `<id-A>=dev (safe)`, `<id-B>=prod (ask first)` | Cite this before mutating commands |
+| Allowed scope | `sync-config only` vs `sync-config + service-config authorized` | Default sync-config only until operator broadens |
 
-Before acting on a saved entry that names a specific instance, file path, or CLI binary, verify it still matches reality (file exists, instance still in `powersync fetch instances`). If it has changed, update the memory rather than acting on a stale value. If saved memory says “prod = do not touch” and the user now asks you to deploy to prod, treat that as a scope expansion and confirm explicitly before proceeding.
+Before acting on a saved entry naming a specific instance, file, or binary: verify it still matches reality. Stale → update the memory, do not act on it. Saved “prod = do not touch” + operator now asks for prod deploy → treat as scope expansion, confirm explicitly.
 
-If your harness has no persistent memory, ask the user the relevant questions at session start and keep the answers in the active conversation.
+No persistent memory in your harness? Ask the operator at session start and keep answers in the active conversation.
 
 
 ## Always Use the PowerSync CLI
 
-**The [PowerSync CLI](https://docs.powersync.com/tools/cli.md) is the default tool for all PowerSync operations.** Do not manually create config files, do not direct users to the dashboard, and do not write `service.yaml` or `sync-config.yaml` from scratch. Only fall back to manual config or dashboard instructions when the user explicitly says they can't use the CLI.
+**The [PowerSync CLI](https://docs.powersync.com/tools/cli.md) is the default tool for all PowerSync operations.** Do not manually create config files, do not direct operators to the dashboard, and do not write `service.yaml` or `sync-config.yaml` from scratch. Fall back to manual config or dashboard instructions only when the operator explicitly says they can't use the CLI.
 
 **Always load `references/powersync-cli.md`** when setting up or modifying a PowerSync instance — it contains the full command reference for Cloud, self-hosted, and Docker workflows.
 
 ## Onboarding Playbook
 
-When the task is to add PowerSync to an app, follow this sequence in order:
+When the task is to add PowerSync to an app, follow this sequence:
 
-1. Identify the platform: **Cloud** or **self-hosted**.
-2. **Identify the backend.** If the user has not specified a backend, **ask them** which database/backend they want to use (e.g. Supabase, custom Postgres, MongoDB, MySQL, MSSQL). Do not assume Supabase. The choice determines which references to load:
-   - **Supabase** → load `references/onboarding-supabase.md`
-   - **Any other backend** → load `references/onboarding-custom.md` — the agent must create a backend API with `uploadData`, token, and JWKS endpoints. Do not skip this.
-3. If the backend is Supabase and it is unclear whether the user means **online (Supabase Cloud)** or **locally hosted** (e.g. `supabase start`), **ask the user** before choosing connection strings, auth config, or references.
-4. Collect required inputs before coding.
-5. **Always load `references/sync-config.md`** and generate sync config. For source database setup (publication SQL, replication, CDC), see `references/powersync-service.md` § "Source Database Setup". Sync config is mandatory for every PowerSync project — without it, nothing syncs.
-6. **Persist all credentials and connection details to `.env` immediately.** When a CLI or dashboard provides database credentials (host, port, database name, username, password, connection URI), write them to the project's `.env` file right away — before deploying config or writing app code. Both `service.yaml` (via `!env` tags) and app code (e.g. `fetchCredentials`) depend on these values. If they are not in `.env`, the PowerSync config will deploy with broken connection details and the app will not connect. Include at minimum: `POWERSYNC_URL`, the Postgres connection URI (e.g. `PS_DATABASE_URI`), and any backend-specific keys.
-7. **Create/link the instance and deploy config before writing app code.** Use the CLI — do not create config files manually. For Cloud: `powersync init cloud` → edit config → `powersync link cloud --create` → `powersync deploy`. For self-hosted: `powersync init self-hosted` → `powersync docker configure` → `powersync docker start`. For source database setup the agent cannot run (e.g. Supabase publication SQL), present the exact SQL and ask the user to confirm it is done. The app will not sync without deployed config.
+1. **Platform.** Cloud or self-hosted?
+2. **Backend.** If unspecified, ask (Supabase, custom Postgres, MongoDB, MySQL, MSSQL). Do not assume Supabase. Then load:
+   - Supabase → `references/onboarding-supabase.md`
+   - Anything else → `references/onboarding-custom.md` (must create a backend API with `uploadData`, token, and JWKS endpoints — do not skip this)
+3. **Supabase online or local?** If unclear from project/env, ask before choosing connection strings, auth config, or references.
+4. Collect required inputs before coding (see "Required Inputs Below").
+5. **Load `references/sync-config.md`** and generate sync config. Source DB setup (publication SQL, replication, CDC) → `references/powersync-service.md` § "Source Database Setup". Without sync config, nothing syncs.
+6. **Persist credentials to `.env` immediately.** When a CLI or dashboard returns DB credentials (host, port, db name, username, password, URI), write them to `.env` *before* deploying config or writing app code. `service.yaml` (`!env`) and app code (`fetchCredentials`) read from there. Minimum: `POWERSYNC_URL`, the Postgres URI (e.g. `PS_DATABASE_URI`), and any backend-specific keys.
+7. **Create/link the instance and deploy config before app code.** CLI only — do not hand-create config files.
+   - Cloud: `powersync init cloud` → edit config → `powersync link cloud --create` → `powersync deploy`
+   - Self-hosted: `powersync init self-hosted` → `powersync docker configure` → `powersync docker start`
+   - Source DB steps the agent cannot run (e.g. Supabase publication SQL): present the exact SQL, ask the operator to confirm done.
 8. Only after backend readiness is confirmed, implement app-side PowerSync integration.
 
-Do not start client-side debugging while the PowerSync service is still unconfigured. If the UI is stuck on `Syncing...`, the default diagnosis is incomplete backend setup, not a frontend bug.
+UI stuck on `Syncing...`? Default diagnosis is incomplete backend setup, not a frontend bug. Do not start client-side debugging while the service is unconfigured.
 
 ## Install Latest Dependencies
 
-Always install PowerSync packages with `@latest` to get critical fixes and the most current API:
+Always install PowerSync packages with `@latest`:
 
 ```bash
 npm install @powersync/web@latest        # or react-native, node, etc.
 npm install @journeyapps/wa-sqlite@latest
 ```
 
-Never omit `@latest` for `@powersync/*` and `@journeyapps/*` packages. These packages release frequently and older cached versions can be missing critical fixes or new APIs the sync config depends on.
+Never omit `@latest` for `@powersync/*` and `@journeyapps/*`. They release frequently; older cached versions miss critical fixes and APIs the sync config depends on.
 
 ## Critical Footguns
 
-These apply to all paths. Domain-specific pitfalls are documented in the relevant reference files — only load those when working on that domain.
+These apply to all paths. Domain-specific pitfalls are in their reference files — only load those when working in that domain.
 
-- After any CLI operation that provisions or links a service (Supabase, PowerSync, or any backend), immediately write the resulting credentials and URLs to the project `.env` file. Do not defer this — downstream config and app code read from `.env` and will break silently if values are missing.
-- `powersync pull instance` silently overwrites local `service.yaml` and `sync-config.yaml`. Always back up before pulling.
+- After any CLI op that provisions or links a service (Supabase, PowerSync, any backend), write the resulting credentials and URLs to `.env` immediately. Downstream config and app code read from `.env` and break silently if values are missing.
+- `powersync pull instance` silently overwrites local `service.yaml` + `sync-config.yaml`. Back up before pulling.
 
-Additional footguns are in their reference files — do not load these unless working in that area:
+Additional footguns by area (do not load unless working there):
 - **Config/CLI:** `references/powersync-cli.md`, `references/powersync-service.md`, `references/sync-config.md`
-- **JS/TS SDK:** `references/sdks/powersync-js.md` (type-only imports, connect() semantics, transaction.complete())
+- **JS/TS SDK:** `references/sdks/powersync-js.md` (type-only imports, `connect()` semantics, `transaction.complete()`)
 - **React:** `references/sdks/powersync-js-react.md` (Strict Mode, Suspense, Next.js)
 - **Supabase:** `references/supabase-auth.md` (JWT signing keys, publication SQL, local Supabase)
 - **Custom backend:** `references/custom-backend.md` (upload endpoint rules, JWT pitfalls)
 
 ## Required Inputs Before Coding
 
-Collect the minimum required information for the chosen path before changing app code.
+Collect the minimum for the chosen path before changing app code. Only ask for secrets when you reach the step that needs them.
 
 ### All paths
 
-- Which backend/database (do not assume Supabase — ask if not specified)
+- Backend/database (do not assume Supabase — ask if unspecified)
 - Whether the PowerSync instance already exists
-- PowerSync instance URL, if an instance already exists
-- Project ID and instance ID, if using CLI with an existing instance
-- Source database connection string, if PowerSync still needs the source DB connection
+- PowerSync instance URL, if it exists
+- Project ID + instance ID, if using CLI with an existing instance
+- Source DB connection string, if PowerSync still needs it
 
 ### Additional for Supabase
 
-- **Whether Supabase is online (hosted at supabase.com) or locally hosted** (e.g. `supabase start`) — if you cannot infer this from the project or env, **prompt the user**
-- Whether Supabase JWT signing uses new signing keys or legacy JWT secret, if not obvious from the setup
+- Supabase online (supabase.com) or locally hosted (`supabase start`)? If unclear from project/env, ask the operator.
+- JWT signing: new signing keys or legacy JWT secret, if not obvious from setup.
 
 ### Additional for custom backends
 
-- How the user wants to handle auth (custom JWT, third-party auth provider)
-- Whether they have an existing backend API or need to create one (load `references/custom-backend.md`)
-
-Only ask for secrets when you are at the step that actually needs them.
+- Auth approach (custom JWT, third-party auth provider)
+- Existing backend API or build one (load `references/custom-backend.md`)
 
 ## Cloud Readiness Gate
 
-Do not proceed to app-side code until all items below are verified:
+Do not proceed to app-side code until **all** items below are verified:
 
 - PowerSync instance exists
 - Source database connection is configured
@@ -132,34 +144,32 @@ Do not proceed to app-side code until all items below are verified:
 - Client auth is configured
 - Instance URL is available for `fetchCredentials()`
 - Source database replication/publication setup is complete
-- All credentials and URLs are persisted in `.env` (e.g. `POWERSYNC_URL`, `PS_DATABASE_URI`, and any backend-specific keys)
+- All credentials and URLs are in `.env` (e.g. `POWERSYNC_URL`, `PS_DATABASE_URI`, plus any backend-specific keys)
 
-If any item is missing, finish the service setup first.
-
-Use the CLI to verify and complete any missing items. For steps the agent cannot perform (e.g. running SQL in the database), present the exact commands and ask the user to confirm completion before writing app code.
+Missing item? Finish service setup first. Use the CLI to verify and complete. For steps the agent cannot perform (e.g. running SQL in the source DB), present the exact commands and ask the operator to confirm completion before writing app code.
 
 ## First Response for `Syncing...`
 
-Follow `references/powersync-debug.md` § "First Response When the UI Is Stuck on `Syncing...`" — verify backend readiness (endpoint URL, DB connection, sync config, client auth, replication/publication) before inspecting frontend code or requesting console logs.
+Follow `references/powersync-debug.md` § "First Response When the UI Is Stuck on `Syncing...`" — verify backend readiness (endpoint URL, DB connection, sync config, client auth, replication/publication) *before* inspecting frontend code or requesting console logs.
 
 ## Setup Paths
 
-Choose the matching path after the preflight. The CLI is the default for all paths.
+Choose the matching path after the preflight. CLI is the default for all paths.
 
 ### Path 1: Cloud + CLI (Recommended)
 
 Load `references/powersync-cli.md` and prefer the CLI for every step it supports:
 
-- Create and link the instance: `powersync link cloud --create --project-id=<project-id>`
+- Create + link: `powersync link cloud --create --project-id=<project-id>`
 - Deploy service config: `powersync deploy service-config`
 - Deploy sync config: `powersync deploy sync-config`
-- Prefer `PS_ADMIN_TOKEN` in autonomous or noninteractive environments; use **`powersync login` only for Cloud** (stores a Cloud PAT), and only when interactive auth is acceptable
+- Prefer `PS_ADMIN_TOKEN` in autonomous/noninteractive environments. **`powersync login` is Cloud-only** (Cloud PAT) and only when interactive auth is acceptable.
 
 ### Path 2: Cloud + Dashboard
 
-Only use this path if the user explicitly prefers the dashboard or the CLI is unavailable.
+Use only when the operator explicitly prefers the dashboard or the CLI is unavailable.
 
-Guide the user through the dashboard sequence:
+Dashboard sequence:
 
 1. Create or open the PowerSync project and instance.
 2. Connect the source database.
@@ -168,21 +178,21 @@ Guide the user through the dashboard sequence:
 5. Copy the instance URL.
 6. Verify source database replication/publication setup.
 
-If the backend is Supabase, also load `references/supabase-auth.md`.
+Backend is Supabase? Also load `references/supabase-auth.md`.
 
 ### Path 3: Self-Hosted + CLI (Recommended)
 
-Load `references/powersync-cli.md`, `references/powersync-service.md`, and `references/sync-config.md`. Prefer the CLI for Docker runs (`powersync docker run`, `powersync docker reset`), schema generation, and any supported self-hosted operations. Remember: **`powersync login` is Cloud-only** — see `references/powersync-cli.md` § “Authentication” for self-hosted auth.
+Load `references/powersync-cli.md`, `references/powersync-service.md`, and `references/sync-config.md`. Prefer the CLI for Docker (`powersync docker run`, `powersync docker reset`), schema generation, and any supported self-hosted op. Reminder: **`powersync login` is Cloud-only** — see `references/powersync-cli.md` § “Authentication” for self-hosted auth.
 
 ### Path 4: Self-Hosted + Manual Docker
 
-Only when the CLI cannot be used. Load `references/powersync-service.md` and `references/sync-config.md`. If the backend is **not** Supabase, also load `references/custom-backend.md`.
+Only when the CLI cannot be used. Load `references/powersync-service.md` and `references/sync-config.md`. Backend not Supabase? Also load `references/custom-backend.md`.
 
 ## Architecture, Routing, SDK Tables & Key Rules
 
-These are defined once in **SKILL.md** — refer there for:
+Defined once in **SKILL.md** — refer there for:
 
-- **Architecture diagram** — shows the read/sync path (PowerSync Service → SDK) and write path (upload queue → your backend API)
-- **"What to Load for Your Task"** table — maps tasks to starter files and on-demand files
-- **SDK Reference Files** tables — maps frameworks/platforms to reference files
+- **Architecture diagram** — read/sync path (PowerSync Service → SDK) and write path (upload queue → your backend API)
+- **"What to Load for Your Task"** table — tasks → starter and on-demand files
+- **SDK Reference Files** tables — frameworks/platforms → reference files
 - **"Key Rules to Apply Without Being Asked"** — `id` column, `connect()`, `transaction.complete()`, `disconnectAndClear()`, 4xx upload handling

--- a/skills/powersync/SKILL.md
+++ b/skills/powersync/SKILL.md
@@ -16,15 +16,22 @@ Use this skill to onboard a project onto PowerSync without trial-and-error. Trea
 
 **Agents: Read [AGENTS.md](AGENTS.md) before proceeding.** It contains the mandatory compliance rules and onboarding playbook. The Quick Rules below are a reminder, not a substitute. **`powersync login`** is **PowerSync Cloud only** (PAT); self-hosted does not use it.
 
+## Terminology
+
+- **Operator** — the human directing this agent (whose request you are fulfilling).
+- **User** — an end-user of the operator's PowerSync app (JWT subjects, the row a sync stream filters by, the person calling `disconnectAndClear()`).
+
+If a sentence is ambiguous, default to the operator interpretation. Full legend in `AGENTS.md`.
+
 ## Quick Rules
 
 - **CLI-first.** Use the [PowerSync CLI](https://docs.powersync.com/tools/cli.md) for all operations. Do not hand-write config files. See `references/powersync-cli.md`.
-- **Ask, don't assume.** Ask Cloud vs self-hosted. Ask which backend (Supabase, Postgres, MongoDB, MySQL, MSSQL). Do not default to Supabase.
+- **Ask, don't assume.** Ask the operator: Cloud vs self-hosted, and which backend (Supabase, Postgres, MongoDB, MySQL, MSSQL). Do not default to Supabase.
 - **Backend before frontend.** Deploy sync config and verify the service before writing app code.
 - **Sync Streams for new projects.** Sync Rules are legacy.
 - **Persist credentials immediately.** Write all URLs and keys to `.env` as soon as they are available.
-- **Default scope on existing projects: sync-config only.** Do not edit `service.yaml` or `cli.yaml` unless the user explicitly authorized service/infra changes in this conversation.
-- **Confirm the target instance before any mutating command** (`deploy`, `destroy`, `stop`, `link --create`, `pull instance`). Never deploy to an instance you have not been authorized for. Treat production as off-limits unless explicitly approved.
+- **Default scope on existing projects: sync-config only.** Do not edit `service.yaml` or `cli.yaml` unless the operator explicitly authorized service/infra changes in this conversation.
+- **Confirm the target instance before any mutating command** (`deploy`, `destroy`, `stop`, `link --create`, `pull instance`). Never deploy to an instance not authorized by the operator. Treat production as off-limits unless explicitly approved.
 - **Use project memory.** If your harness supports it, persist the CLI invocation, sync-config path, authorized instance ids + environment (dev/staging/prod), and allowed scope of changes. Verify saved values still match reality before acting on them. See `AGENTS.md` § "Continuous Use & Guardrails".
 
 ## What to Load for Your Task

--- a/skills/powersync/references/onboarding-custom.md
+++ b/skills/powersync/references/onboarding-custom.md
@@ -11,7 +11,7 @@ metadata:
 
 Use this recipe when onboarding any app onto PowerSync with a **non-Supabase backend** — your own database, your own auth, and your own backend API. Works for all platforms (web, React Native, Flutter, Kotlin, Swift, .NET, etc.) and both Cloud and self-hosted.
 
-**CLI-first.** See `references/powersync-cli.md`. Fall back to the dashboard (Cloud) or manual Docker config (self-hosted) only if the CLI is unavailable or the user explicitly prefers it.
+**CLI-first.** See `references/powersync-cli.md`. Fall back to the dashboard (Cloud) or manual Docker config (self-hosted) only if the CLI is unavailable or the operator explicitly prefers it.
 
 ## Required Inputs
 
@@ -23,7 +23,7 @@ Collect before writing any code:
 - Whether a PowerSync instance already exists
 - PowerSync instance URL (if instance exists)
 - Project ID and instance ID (if using CLI with existing Cloud instance)
-- How the user wants to handle auth (custom JWT, third-party provider like Auth0/Firebase, or dev tokens)
+- How the operator wants to handle auth (custom JWT, third-party provider like Auth0/Firebase, or dev tokens)
 - Whether they have an existing backend API or need to create one
 
 Only ask for secrets (database password, private keys) when you are at the step that actually needs them.
@@ -36,7 +36,7 @@ Follow this sequence exactly. **Do not skip ahead to app code.**
 
 1. **Confirm the path.** Verify: PowerSync (Cloud or self-hosted) + custom backend + your platform.
 
-2. **Set up the source database.** Load `references/powersync-service.md` § "Source Database Setup" for the relevant quick start (Postgres, MongoDB, MySQL, or MSSQL). Present the exact SQL to the user and ask them to confirm it is done.
+2. **Set up the source database.** Load `references/powersync-service.md` § "Source Database Setup" for the relevant quick start (Postgres, MongoDB, MySQL, or MSSQL). Present the exact SQL to the operator and ask them to confirm it is done.
 
 3. **Write credentials to `.env` immediately.** As soon as database details are available:
    ```

--- a/skills/powersync/references/onboarding-supabase.md
+++ b/skills/powersync/references/onboarding-supabase.md
@@ -11,7 +11,7 @@ metadata:
 
 Use this recipe when onboarding any app onto PowerSync Cloud with a Supabase backend. This works for all platforms (web, React Native, Flutter, Kotlin, Swift, .NET, etc.).
 
-**CLI-first.** See `references/powersync-cli.md`. Fall back to the dashboard only if the CLI is unavailable or the user explicitly prefers it.
+**CLI-first.** See `references/powersync-cli.md`. Fall back to the dashboard only if the CLI is unavailable or the operator explicitly prefers it.
 
 ## Required Inputs
 
@@ -37,7 +37,7 @@ Follow this sequence exactly. **Do not skip ahead to app code.**
 
 2. **Write credentials to `.env` immediately.** As soon as Supabase project details are available, write `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `PS_DATABASE_URI`, and `POWERSYNC_URL` to `.env`. Both `service.yaml` (via `!env` tags) and app code depend on these values. For how to get `POWERSYNC_URL`, see `references/powersync-cli.md` § "Getting POWERSYNC_URL".
 
-3. **Run the Supabase publication SQL.** The publication must exist before PowerSync connects to the database. See `references/supabase-auth.md` § "Supabase Database Setup" for the exact SQL. Present it to the user and ask them to confirm.
+3. **Run the Supabase publication SQL.** The publication must exist before PowerSync connects to the database. See `references/supabase-auth.md` § "Supabase Database Setup" for the exact SQL. Present it to the operator and ask them to confirm.
 
 4. **Scaffold and configure PowerSync.**
    - **New instance (CLI):** `powersync init cloud` → edit config → `powersync link cloud --create --project-id=<id>` → deploy

--- a/skills/powersync/references/powersync-cli.md
+++ b/skills/powersync/references/powersync-cli.md
@@ -25,7 +25,7 @@ The PowerSync CLI manages Cloud and self-hosted PowerSync instances from the com
 
 ## Recommended Defaults for Agents
 
-Use these defaults unless the user explicitly wants something else:
+Use these defaults unless the operator explicitly wants something else:
 
 - Prefer `PS_ADMIN_TOKEN` in autonomous or noninteractive environments.
 - **`powersync login` is Cloud-only** (stores a Cloud PAT). Do not present it as the auth path for self-hosted-only setups.
@@ -41,25 +41,25 @@ Use these defaults unless the user explicitly wants something else:
 
 ## Mutating Commands — Confirm Before Running
 
-These commands change Cloud state or local config. On an existing project, do not run them without confirming the target instance and that the user has authorized the change.
+These commands change Cloud state or local config. On an existing project, do not run them without confirming the target instance and that the operator has authorized the change.
 
 | Command | Effect | Required check |
 |---------|--------|----------------|
-| `powersync deploy` | Pushes `service.yaml` + `sync-config.yaml` to the linked instance | Confirm instance id and that user authorized deploying both files. If only sync streams changed, prefer `powersync deploy sync-config`. |
-| `powersync deploy service-config` | Replaces service config (replication, storage, auth) on the linked instance | Service-config edits are out-of-scope by default — get explicit user authorization in this conversation before running. |
-| `powersync deploy sync-config` | Replaces sync config on the linked instance | Confirm instance id + environment (dev/staging/prod) before running. Never deploy to a production instance the user has not approved. |
+| `powersync deploy` | Pushes `service.yaml` + `sync-config.yaml` to the linked instance | Confirm instance id and that the operator authorized deploying both files. If only sync streams changed, prefer `powersync deploy sync-config`. |
+| `powersync deploy service-config` | Replaces service config (replication, storage, auth) on the linked instance | Service-config edits are out-of-scope by default — get explicit operator authorization in this conversation before running. |
+| `powersync deploy sync-config` | Replaces sync config on the linked instance | Confirm instance id + environment (dev/staging/prod) before running. Never deploy to a production instance the operator has not approved. |
 | `powersync destroy --confirm=yes` | Permanently destroys the linked Cloud instance | Always require explicit, in-conversation confirmation naming the instance. Treat as one-shot authorization. |
-| `powersync stop --confirm=yes` | Stops the linked Cloud instance (clients lose sync) | Same as `destroy` — confirm instance and that the user accepts downtime. |
-| `powersync link cloud --create` | Creates a new Cloud instance | Only during initial bootstrap. Do not run on a project that already has a linked instance unless the user explicitly wants a second one. |
-| `powersync pull instance` | Overwrites local `service.yaml` and `sync-config.yaml` from the remote | Back up local files first. Do not run after local edits unless the user accepts losing them. |
+| `powersync stop --confirm=yes` | Stops the linked Cloud instance (clients lose sync) | Same as `destroy` — confirm instance and that the operator accepts downtime. |
+| `powersync link cloud --create` | Creates a new Cloud instance | Only during initial bootstrap. Do not run on a project that already has a linked instance unless the operator explicitly wants a second one. |
+| `powersync pull instance` | Overwrites local `service.yaml` and `sync-config.yaml` from the remote | Back up local files first. Do not run after local edits unless the operator accepts losing them. |
 
 **How to confirm the target instance.** Before any command in the table:
 
-1. Run `powersync fetch instances` (or read `powersync/cli.yaml`) and tell the user the instance id, project id, and — if known from project memory — its environment.
-2. If the environment is production or unknown, ask before proceeding. Do not assume "linked" means "safe."
-3. One approval covers one command. Re-confirm for the next mutating command.
+1. Run `powersync fetch instances` (or read `powersync/cli.yaml`) and tell the operator the instance id, project id, and — if known from project memory — its environment.
+2. Production or unknown environment? Ask before proceeding. Do not assume "linked" means "safe."
+3. One approval = one command. Re-confirm for the next mutating command.
 
-**Default scope on existing projects.** Only edit and deploy `sync-config.yaml`. Leave `service.yaml` and `cli.yaml` alone unless the user has authorized service/infra changes in this conversation. See `AGENTS.md` § "Continuous Use & Guardrails".
+**Default scope on existing projects.** Edit and deploy `sync-config.yaml` only. Leave `service.yaml` and `cli.yaml` alone unless the operator has authorized service/infra changes in this conversation. See `AGENTS.md` § "Continuous Use & Guardrails".
 
 ## Recommended Cloud Sequence
 
@@ -104,11 +104,11 @@ For Cloud, `--org-id` / `ORG_ID` is optional — omit it when your token has acc
 | **PowerSync Cloud** | `PS_ADMIN_TOKEN` (PAT) or token from **`powersync login`** |
 | **Self-hosted** | No `powersync login` for the running service. Use **`powersync init self-hosted`**, **`powersync docker configure` / `powersync docker start`**, and **`PS_ADMIN_TOKEN`** matching the self-hosted service’s admin API token (see self-hosted docs). |
 
-Do not tell users to run `powersync login` when they are **only** using a local self-hosted stack unless they also need Cloud CLI commands.
+Do not tell the operator to run `powersync login` when they are **only** using a local self-hosted stack unless they also need Cloud CLI commands.
 
 ---
 
-Cloud commands require a PowerSync personal access token (PAT). If the user does not have one, direct them to generate one at: https://dashboard.powersync.com/account/access-tokens
+Cloud commands require a PowerSync personal access token (PAT). If the operator does not have one, direct them to generate one at: https://dashboard.powersync.com/account/access-tokens
 
 Prefer `PS_ADMIN_TOKEN` when the environment is noninteractive or when the agent should avoid browser/device-login interruptions.
 
@@ -184,7 +184,7 @@ password: secret_ref: default_password
 
 ### New Cloud Instance
 
-**Information the agent must collect from the user before proceeding:**
+**Information the agent must collect from the operator before proceeding:**
 - PowerSync account (if they don't have one, direct to https://dashboard.powersync.com to sign up)
 - A project on the dashboard (required before creating an instance — if they don't have one, they must create one at https://dashboard.powersync.com first)
 - Project ID (find on dashboard or via `powersync fetch instances` after login)
@@ -201,7 +201,7 @@ powersync login                               # opens browser for PAT
 powersync init cloud                          # creates powersync/ with service.yaml and sync-config.yaml
 ```
 
-**After `powersync init cloud`:** Read the generated `powersync/service.yaml` and `powersync/sync-config.yaml`. These contain placeholder values. Prompt the user for their database connection details and edit the files before continuing.
+**After `powersync init cloud`:** Read the generated `powersync/service.yaml` and `powersync/sync-config.yaml`. These contain placeholder values. Prompt the operator for their database connection details and edit the files before continuing.
 
 ```bash
 # 3. Create instance and deploy
@@ -272,12 +272,12 @@ Write it to `.env` as `POWERSYNC_URL=https://<instance-id>.powersync.journeyapps
 
 ### Existing Cloud Instance
 
-**Information the agent must collect from the user:**
+**Information the agent must collect from the operator:**
 - Project ID
 - Instance ID
 - Org ID (only if token covers multiple orgs)
 
-The user can find these on the PowerSync Dashboard or by running `powersync fetch instances` after `powersync login`.
+The operator can find these on the PowerSync Dashboard or by running `powersync fetch instances` after `powersync login`.
 
 ```bash
 powersync login
@@ -331,10 +331,10 @@ The CLI manages a full Docker Compose stack for local development and testing.
 
 **Prerequisites:** Docker and Docker Compose V2 (2.20.3+).
 
-**Information the agent may need from the user:**
+**Information the agent may need from the operator:**
 - If using `--database external`: the source database URI (set as `PS_DATA_SOURCE_URI`)
 - If using `--storage external`: the storage database URI (set as `PS_STORAGE_SOURCE_URI`)
-- If using the default options: no user input needed — the CLI provisions local Postgres for both
+- If using the default options: no operator input needed — the CLI provisions local Postgres for both
 
 **Step-by-step:**
 
@@ -351,7 +351,7 @@ powersync docker configure
 powersync docker start                        # docker compose up -d --wait
 ```
 
-**After `powersync init self-hosted`:** Read the generated `powersync/service.yaml`. If the user is connecting to an external database, prompt them for the connection URI and update the file. The `powersync docker configure` command will merge Docker-specific settings into `service.yaml` and write `cli.yaml`.
+**After `powersync init self-hosted`:** Read the generated `powersync/service.yaml`. If the operator is connecting to an external database, prompt them for the connection URI and update the file. The `powersync docker configure` command will merge Docker-specific settings into `service.yaml` and write `cli.yaml`.
 
 ```bash
 # 4. Verify and use the instance
@@ -365,7 +365,7 @@ powersync generate token --subject=user-test-1
 
 For self-hosted instances already running (not managed by the CLI), the CLI can link to them for schema generation, token generation, and status checks.
 
-**Information the agent must collect from the user:**
+**Information the agent must collect from the operator:**
 - API URL of the running PowerSync instance
 - API token (must match a token configured in the instance's `api.tokens` setting)
 

--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -25,7 +25,7 @@ Before asking for console logs or editing app code, verify these in order:
 
 Only inspect frontend connector code or SDK state after all five checks pass.
 
-Before requesting browser console logs, ask the user to confirm:
+Before requesting browser console logs, ask the operator to confirm:
 
 - the instance exists
 - the DB connection was configured

--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -208,7 +208,7 @@ See [PowerSync Cloud Instances](https://docs.powersync.com/configuration/powersy
 
 ## Source Database Setup
 
-Important: For all database user creation below, generate a cryptographically secure password (e.g., `openssl rand -base64 32` or a password manager). Never use placeholder values like `secure_password`, `password`, or `admin123` in production—these are unsafe and must not be suggested to users.
+Important: For all database user creation below, generate a cryptographically secure password (e.g., `openssl rand -base64 32` or a password manager). Never use placeholder values like `secure_password`, `password`, or `admin123` in production — these are unsafe and must not be suggested to the operator.
 
 See [Source Database Setup](https://docs.powersync.com/configuration/source-db/setup.md) for more information about specific DB host requirements. 
 


### PR DESCRIPTION
### Why
"User" means too many things. In a project's `CLAUDE.md`, "the user" is the human talking to the agent. But a PowerSync app is also full of `auth.user_id()`, `disconnectAndClear()` on user switch, and JWT user subjects. When this skill loads into a context that already has `CLAUDE.md` rules about "the user," the agent has to figure out which "user" each instruction means. Renaming one of them gets rid of that confusion, and it's the direction other tools are going too. Reported by someone who hit this during long sessions.

### Changes
- Added a "Terminology" legend at the top of `AGENTS.md`, with a short version in `SKILL.md`.
- Renamed operator-directed "user" to "operator" across `AGENTS.md`, SKILL.md, `references/powersync-cli.md`, and four other reference files. Every app-domain "user" (JWT subjects, RLS, sign-out, sync filters) is left untouched.
- Compressed the `AGENTS.md` "Continuous Use & Guardrails" section into bullets, decision-tree phrasing, and a 4-row project-memory table. The "why" lines are preserved.

### Validation
Ran 6 targeted evals comparing this version against the previous (round-1 guardrails). Both versions passed all 6:
- operator/user disambiguation
- sync-config scope
- instance confirmation before deploy
- destroy command confirmation
- project memory persistence
- a negative test for over-prompting

No regression on any evaluation. The eval set couldn't isolate a positive lift on its own. The operator rename's main payoff shows up in collisions with project `CLAUDE.md`, which a single-shot eval doesn't simulate.