### PR TITLE
Bring skills in line with a few recent updates

### DIFF
--- a/skills/powersync/references/attachments.md
+++ b/skills/powersync/references/attachments.md
@@ -82,7 +82,7 @@ npx expo install @powersync/attachments-storage-react-native expo-file-system
 npm install @powersync/attachments-storage-react-native @dr.pogodin/react-native-fs
 ```
 
-**Flutter/Dart, Kotlin, Swift** — built in to the respective SDK, no additional package needed.
+**Flutter/Dart, Kotlin, Swift, .NET** — built in to the respective SDK, no additional package needed.
 
 ## Schema Setup
 
@@ -116,6 +116,21 @@ final schema = Schema([
 ```
 
 **Kotlin / Swift** — use `createAttachmentsTable("attachments")` / `createAttachmentTable(name: "attachments")` respectively. See [SDK demos](https://docs.powersync.com/client-sdks/advanced/attachments.md#sdk--demo-reference) for full examples.
+
+**.NET:**
+```csharp
+using PowerSync.Common.Attachments;
+using PowerSync.Common.DB.Schema;
+
+var users = new Table("users", new Dictionary<string, ColumnType>
+{
+    ["name"] = ColumnType.Text,
+    ["photo_id"] = ColumnType.Text,  // FK referencing attachment ID
+});
+
+// new Table(typeof(Attachment)) uses the built-in [Table("attachments", LocalOnly = true)] attribute
+var schema = new Schema(users, new Table(typeof(Attachment)));
+```
 
 ## Storage Adapters
 

--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -55,28 +55,17 @@ Each of the PowerSync Client SDKs have the SyncStatus class that can be used to 
 
 Key fields to check: `connected`, `downloading`, `uploading`, `lastSyncedAt`, `hasSynced`, `downloadError`, `uploadError`.
 
-## Enable `newClientImplementation: false` (Swift SDK only)
-
-What it identifies: Authentication failures, JWT errors, and endpoint misconfigurations that are silently swallowed by the default WebSocket client on Apple platforms.
-
-Why: The default WebSocket-based sync client on iOS/macOS restricts logging due to platform constraints. Switching to `newClientImplementation: false` uses the HTTP streaming client instead, which produces full request/response logs including headers, status codes, and error bodies. The actual 401 + `PSYNC_S2101` error that pointed to a JWT key mismatch was only visible after this switch.
-
-How: In the `connect` function for each of the PowerSync Client SDKs, disable the Rust Sync Client / disable `newClientImplementation`.
-
-Revert after debugging: The default WebSocket client is preferred for production.
-
 ## Enable the Request Logger (Swift SDK)
 
-What it identifies: The exact HTTP request being made to the PowerSync Service to inspect the URL, method, headers, authorization token, and response status code.
+What it identifies: The exact HTTP request being made to the PowerSync Service to inspect the URL, method, headers, authorization token, and response status code. Use this when authentication failures, JWT errors, or endpoint misconfigurations need to be diagnosed on iOS/macOS.
 
-Why: Even with `newClientImplementation: false`, request details aren't logged by default. Adding a `SyncRequestLoggerConfiguration` gives you a full audit trail of every sync stream request, which lets you verify the `endpoint` URL is correct and the JWT is being sent.
+Why: The Rust-based sync client doesn't log request details by default. Adding a `SyncRequestLoggerConfiguration` gives a full audit trail of every sync stream request — `endpoint` URL, JWT, response status, and error bodies (including `PSYNC_S2101` JWT key-id mismatches).
 
 How:
 ```swift
 try await db.connect(
     connector: connector,
     options: ConnectOptions(
-        newClientImplementation: false,
         clientConfiguration: SyncClientConfiguration(
             requestLogger: SyncRequestLoggerConfiguration(
                 requestLevel: .headers

--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -699,7 +699,7 @@ These advanced topics are in separate files — load only when needed:
 
 ### Sync Client Implementations
 
-The Rust-based sync client is now the default — no config needed. The legacy JS client (`SyncClientImplementation.JAVASCRIPT`) is deprecated. Do not downgrade the SDK after using the Rust client — older JS client versions can't read the Rust format.
+The Rust-based sync client is now the only sync client. The legacy JavaScript client (`SyncClientImplementation.JAVASCRIPT` / `@LegacySyncImplementation` APIs) has been removed from `@powersync/common`, `@powersync/web`, and `@powersync/react-native` and is no longer an option. Do not downgrade the SDK to a version that still shipped the JS client — older versions can't read the Rust client's storage format.
 
 ### QueryStore
 

--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -714,14 +714,14 @@ CRUD upload ops (`UpdateType`): `PUT`, `PATCH`, `DELETE` — what you see in `up
 
 See [Debugging Overview](https://docs.powersync.com/debugging/tools-and-techniques.md) for the full list of tools and techniques.
 
-### Diagnostics App
+### Sync Diagnostics Client
 
 https://diagnostics-app.powersync.com
 
 Connect this to a running PowerSync instance to inspect tables, rows, sync buckets, and run arbitrary SQL against the local database. This is the fastest way to isolate whether a problem is in the PowerSync service or in the client:
 
-- If the diagnostics app shows the correct data → the service is syncing correctly → the issue is in your client code (query, schema, rendering)
-- If the diagnostics app shows incorrect or missing data → the issue is in the PowerSync service configuration (sync rules, backend connector, permissions)
+- If the Sync Diagnostics Client shows the correct data → the service is syncing correctly → the issue is in your client code (query, schema, rendering)
+- If the Sync Diagnostics Client shows incorrect or missing data → the issue is in the PowerSync service configuration (sync rules, backend connector, permissions)
 
 ### Enable SDK Logging (Development)
 

--- a/skills/powersync/references/sdks/powersync-kotlin.md
+++ b/skills/powersync/references/sdks/powersync-kotlin.md
@@ -45,17 +45,7 @@ commonMain.dependencies {
 }
 ```
 
-For iOS with Cocoapods (recommended over SPM for iOS targets):
-
-```kotlin
-cocoapods {
-    pod("powersync-sqlite-core") { linkOnly = true }
-    framework {
-        isStatic = true
-        export("com.powersync:core")
-    }
-}
-```
+From v1.12.0+ the PowerSync SQLite core extension is statically linked into `com.powersync:core` for all Apple targets (iOS, macOS, tvOS, watchOS), matching Android and JVM. **No CocoaPod or Swift Package dependency on `powersync-sqlite-core` is needed.** Upgrading from an older version? Remove any `pod("powersync-sqlite-core")` entry and any `powersync-sqlite-core-swift` SPM dependency.
 
 ## Quick Setup
 
@@ -449,8 +439,8 @@ Full example: [`demos/supabase-todolist/androidBackgroundSync`](https://github.c
 
 ## ORM Integrations
 
-- **Room** (alpha) — typed queries with compile-time validation: `com.powersync:powersync-room:$powersyncVersion` · [Docs](https://docs.powersync.com/client-sdk-references/kotlin-multiplatform/libraries/room.md)
-- **SQLDelight** (beta) — `PowerSyncDriver` implements `SqlDriver`: `com.powersync:powersync-sqldelight:$powersyncVersion` · [Docs](https://docs.powersync.com/client-sdk-references/kotlin-multiplatform/libraries/sqldelight.md)
+- **Room** (beta) — typed queries with compile-time validation: `com.powersync:powersync-room:$powersyncVersion` · [Docs](https://docs.powersync.com/client-sdks/orms/kotlin/room.md)
+- **SQLDelight** (beta) — `PowerSyncDriver` implements `SqlDriver`: `com.powersync:powersync-sqldelight:$powersyncVersion` · [Docs](https://docs.powersync.com/client-sdks/orms/kotlin/sqldelight.md)
 
 ## Additional Resources
 

--- a/skills/powersync/references/sync-config.md
+++ b/skills/powersync/references/sync-config.md
@@ -45,7 +45,7 @@ config:
 There are minimum SDK requirements when using Sync Streams in an application. See [Minimum SDK Versions](https://docs.powersync.com/sync/streams/migration.md#minimum-sdk-versions) for a full list for each supported PowerSync SDK.
 
 IMPORTANT
-Client applications using a lower version than the `Rust Client Default` should make sure to enable the Rust Sync Client to use Sync Streams. 
+Recent SDK versions ship only the Rust sync client, so no opt-in is needed. On older SDKs (pre `Rust Client Default`), explicitly enable the Rust sync client to use Sync Streams.
 
 ## sync-config.yaml File Format
 


### PR DESCRIPTION
Brings the skills in line with recent docs updates flagged via drift [issues](https://github.com/powersync-ja/agent-skills/issues). Each change matches a docs PR that has already merged in https://github.com/powersync-ja/powersync-docs.

- **Kotlin SDK — Room integration is now Beta.** Resolves https://github.com/powersync-ja/agent-skills/issues/28. Source: https://github.com/powersync-ja/powersync-docs/pull/445.
- **Kotlin SDK — drop CocoaPods setup for `powersync-sqlite-core`.** From v1.12.0+ the extension is statically linked into `com.powersync:core` for all Apple targets. Resolves https://github.com/powersync-ja/agent-skills/issues/22. Source: https://github.com/powersync-ja/powersync-docs/pull/435.
- **JS SDK — rename "Diagnostics App" to "Sync Diagnostics Client".** Resolves https://github.com/powersync-ja/agent-skills/issues/24. Source: https://github.com/powersync-ja/powersync-docs/pull/259.
- **.NET — document built-in attachment queue.** Resolves https://github.com/powersync-ja/agent-skills/issues/21. Source: https://github.com/powersync-ja/powersync-docs/pull/437.
- **Legacy sync clients removed — JS, Kotlin, and Swift.** Updated the JS internals note (the legacy JS client is removed, not deprecated) and dropped the now-defunct `newClientImplementation: false` debug technique. Resolves https://github.com/powersync-ja/agent-skills/issues/23. Sources: https://github.com/powersync-ja/powersync-js/pull/938, https://github.com/powersync-ja/powersync-swift/pull/131.

Issue https://github.com/powersync-ja/agent-skills/issues/20 (Swift native rewrite) was left open — the corresponding docs updates have not shipped yet.

---

*AI disclosure: this PR was prepared with Claude Code. Each change was cross-referenced against a merged docs PR before applying.*
