### PR TITLE
Sync from docs: add Kubernetes/Helm Charts self-hosting guidance (powersync-docs #452)

### DIFF
--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -1,13 +1,13 @@
 ---
 name: powersync-service
-description: PowerSync Service configuration — self-hosting, Docker, source database setup, bucket storage, authentication, and PowerSync Cloud
+description: PowerSync Service configuration — self-hosting, Docker, Kubernetes, Helm, source database setup, bucket storage, authentication, and PowerSync Cloud
 metadata:
-  tags: service, self-hosted, docker, postgresql, mongodb, mysql, mssql, authentication, jwt, replication, configuration
+  tags: service, self-hosted, docker, kubernetes, helm, eks, postgresql, mongodb, mysql, mssql, authentication, jwt, replication, configuration
 ---
 
 # PowerSync Service
 
-> **Load this when** configuring the PowerSync service itself — self-hosting, Docker, source database connections, bucket storage, or authentication setup.
+> **Load this when** configuring the PowerSync service itself — self-hosting, Docker, Kubernetes, source database connections, bucket storage, or authentication setup.
 
 ## Table of Contents
 - [Sync Config](#sync-config)
@@ -173,6 +173,50 @@ replication:
 ```
 
 Without this, you will see: `Replication error postgres does not support ssl`.
+
+### Kubernetes / Helm Charts
+
+For Kubernetes deployments (including AWS EKS), use the community-maintained Helm chart. The chart packages the API, replication, compaction, and migration workloads with production defaults.
+
+**Chart repository (source of truth for values, install instructions, and upgrade notes):** https://github.com/powersync-community/powersync-helm-chart
+
+Deploy using standard Helm install/upgrade; configure via `values.yaml` overrides. The PowerSync CLI is not used for Kubernetes deployments.
+
+#### Key Constraints
+
+| Component | Constraint |
+|-----------|------------|
+| Replication | Default 2 replicas = warm standby. **Only one pod replicates at a time.** Do not add replicas to scale throughput — scale vertically instead. If you drop to `replicas: 1`, set the deployment strategy to `Recreate`. |
+| API | Target ~100 connections per pod; hard cap is **200**. Exceeding 200 triggers `PSYNC_S2304` errors. API is stateless — scale out via HPA, not up. |
+| `NODE_OPTIONS` | Leave `--max-old-space-size-percentage=80` as-is. V8 tracks the container memory limit automatically; no recalculation is needed when you change `resources.limits.memory`. |
+
+#### Ingress Requirements
+
+- Use a **dedicated subdomain** (e.g. `powersync.example.com`). PowerSync cannot share a host with other services.
+- Requires HTTP/2 and WebSocket support. Without HTTP/2, sync stream multiplexing degrades.
+- `proxy-buffering: "off"` is **required** for streaming sync — without it responses buffer and stall.
+- Set `proxy-read-timeout` and `proxy-send-timeout` to `3600` to keep long-lived sync streams open.
+- Terminate TLS at the ingress with a real certificate. The placeholder in `values.yaml` will not work in production.
+
+#### Scaling Beyond a Single Instance
+
+A single replication instance handles roughly 50,000–100,000 concurrent clients depending on row size. Past that, run [multiple instances](https://docs.powersync.com/maintenance-ops/self-hosting/multiple-instances) by installing the chart again under a separate Helm release name with its own bucket storage database. The same source database can be shared across installs.
+
+**Important:** Clients must be **pinned to a specific instance**. Each instance maintains its own copy of bucket data — a client switching instances triggers a full resync. Pin clients via your backend (pass the endpoint explicitly) or compute the endpoint deterministically (e.g. `hash(user_id) % n`). Do not load-balance multiple instances behind one host.
+
+#### Observability
+
+Prometheus metrics are exposed on port `9464`. Enable the chart's `NetworkPolicy` (`networkPolicy.enabled: true`) in production to allow scrapes on that port. Key signals:
+
+| Metric | Note |
+|--------|------|
+| `powersync_concurrent_connections` | Primary HPA driver. Alert when a pod nears the 200 hard cap. |
+| `powersync_replication_lag_seconds` | Alert on sustained spikes. |
+| `powersync_replication_storage_size_bytes` | Capacity-plan from the trend. |
+| `powersync_operation_storage_size_bytes` | Capacity-plan from the trend. |
+| `powersync_data_sent_bytes_total` | Egress cost driver. |
+
+See [Metrics](https://docs.powersync.com/maintenance-ops/self-hosting/metrics) for the full metric catalog.
 
 ### Bucket Storage Database
 This is required by PowerSync and can be configured in two different ways. This is separate from the source DB.


### PR DESCRIPTION
_Generated by Claude. Review carefully before merging._\n\n**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/452\n\n**What changed in docs:** Added a new deployment platform page for AWS EKS, documenting how to run the self-hosted PowerSync Service on Kubernetes using the community Helm charts (`powersync-community/powersync-helm-chart`). Covers workload sizing, observability, ingress requirements, horizontal scaling, and the multi-instance pattern.\n\n**Skill updates in this PR:**\n- `skills/powersync/references/powersync-service.md` — added a new `### Kubernetes / Helm Charts` subsection under `## Service Configuration (Self-hosted)`. Content covers:\n  - Helm chart repo link (source of truth for values and upgrade notes)\n  - Replication warm-standby constraint (only 1 pod replicates at a time — do not scale replicas horizontally)\n  - API connection cap (target 100/pod, hard cap 200 → `PSYNC_S2304` errors)\n  - `NODE_OPTIONS` note (leave `--max-old-space-size-percentage=80` as-is)\n  - Ingress requirements (`proxy-buffering: \"off\"` required for streaming, HTTP/2 + WebSocket, dedicated subdomain)\n  - Multi-instance scaling pattern and the client-pinning requirement (switching instances triggers full resync)\n  - Prometheus metrics port (`9464`) and key signals\n- Updated frontmatter `description` and `tags` to include `kubernetes`, `helm`, `eks`\n\n**Notes for reviewer:**\n- The docs page recommends a `NetworkPolicy` (`networkPolicy.enabled: true`) in production — included as a note in the Observability section.\n- The `AGENTS.md` \"Setup Paths\" section currently lists Docker as the only self-hosted path. This PR does not add a Kubernetes path there, since the docs change is a deployment guide rather than an onboarding flow change, and existing routing in `SKILL.md` already directs self-hosting questions to `powersync-service.md`. A reviewer may want to add a brief mention of Helm as a self-hosted alternative in `AGENTS.md` Path 3/4 — flagged here but not done to keep the diff minimal.\n- No new reference file was created; the Kubernetes content fits naturally within the existing `powersync-service.md` scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJPiwRwWAbYnoduPiERu65)_