### PR TITLE
Sync from docs: add powersync compact CLI command (powersync-docs #463)

### DIFF
--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -11,17 +11,17 @@ If a sentence is ambiguous, default to the operator interpretation.
 
 ## Agent compliance (read first — non-negotiable)
 
-**Follow this file’s playbook in order.** Do not skip ahead, assume defaults, or substitute your own architecture to “save time.”
+**Follow this file's playbook in order.** Do not skip ahead, assume defaults, or substitute your own architecture to "save time."
 
-| Do | Don’t |
-|----|--------|
+| Do | Don't |
+|----|-----|
 | **Ask the operator** before doing anything: (1) **Cloud or self-hosted**, (2) **which database** (Supabase, Postgres, MongoDB, MySQL, MSSQL), and (3) **only if not Supabase**, whether they have a backend API or need to build one. Use the **PowerSync CLI** by default for all operations. | Assume any answer, pick a default (e.g. Supabase, Postgres, self-hosted Docker), skip a question, or ask about a backend API when the operator already chose Supabase (Supabase *is* the backend). Do not hand-write config files or use the dashboard unless the operator explicitly says they cannot use the CLI. |
 | Use the **PowerSync CLI** to scaffold, link (if cloud hosted), and deploy (`references/powersync-cli.md`) | Hand-write `service.yaml` / `sync-config.yaml` from scratch or invent compose files **unless** the operator explicitly says they cannot use the CLI |
 | **Stop and ask** when a step needs credentials or interactive Cloud login you cannot perform | Silently build an alternate stack (e.g. manual Docker) without operator confirmation |
 | Complete **backend readiness** (deployed sync config, auth, publication) **before** app code | Start React/client integration while sync is still unconfigured |
 | Use **Sync Streams** (`config: edition: 3`) for new projects | Generate legacy Sync Rules YAML for new projects |
 
-Shortcut requested? Operator must say so explicitly (e.g. “no CLI, dashboard only”).
+Shortcut requested? Operator must say so explicitly (e.g. "no CLI, dashboard only").
 
 ## Continuous Use & Guardrails (existing projects)
 
@@ -35,7 +35,7 @@ The onboarding playbook below assumes a fresh project. On an **existing** projec
 
 ### Confirm the target instance before any mutating command
 
-Mutating commands: `powersync deploy`, `deploy service-config`, `deploy sync-config`, `destroy`, `stop`, `link cloud --create`, `pull instance`.
+Mutating commands: `powersync deploy`, `deploy service-config`, `deploy sync-config`, `destroy`, `stop`, `compact`, `link cloud --create`, `pull instance`.
 
 Before running any of them:
 
@@ -56,7 +56,7 @@ If your harness has a project memory or persistent notes file, record these once
 | Authorized instances + env | `<id-A>=dev (safe)`, `<id-B>=prod (ask first)` | Cite this before mutating commands |
 | Allowed scope | `sync-config only` vs `sync-config + service-config authorized` | Default sync-config only until operator broadens |
 
-Before acting on a saved entry naming a specific instance, file, or binary: verify it still matches reality. Stale → update the memory, do not act on it. Saved “prod = do not touch” + operator now asks for prod deploy → treat as scope expansion, confirm explicitly.
+Before acting on a saved entry naming a specific instance, file, or binary: verify it still matches reality. Stale → update the memory, do not act on it. Saved "prod = do not touch" + operator now asks for prod deploy → treat as scope expansion, confirm explicitly.
 
 No persistent memory in your harness? Ask the operator at session start and keep answers in the active conversation.
 
@@ -182,7 +182,7 @@ Backend is Supabase? Also load `references/supabase-auth.md`.
 
 ### Path 3: Self-Hosted + CLI (Recommended)
 
-Load `references/powersync-cli.md`, `references/powersync-service.md`, and `references/sync-config.md`. Prefer the CLI for Docker (`powersync docker run`, `powersync docker reset`), schema generation, and any supported self-hosted op. Reminder: **`powersync login` is Cloud-only** — see `references/powersync-cli.md` § “Authentication” for self-hosted auth.
+Load `references/powersync-cli.md`, `references/powersync-service.md`, and `references/sync-config.md`. Prefer the CLI for Docker (`powersync docker run`, `powersync docker reset`), schema generation, and any supported self-hosted op. Reminder: **`powersync login` is Cloud-only** — see `references/powersync-cli.md` § "Authentication" for self-hosted auth.
 
 ### Path 4: Self-Hosted + Manual Docker
 

--- a/skills/powersync/references/powersync-cli.md
+++ b/skills/powersync/references/powersync-cli.md
@@ -50,6 +50,7 @@ These commands change Cloud state or local config. On an existing project, do no
 | `powersync deploy sync-config` | Replaces sync config on the linked instance | Confirm instance id + environment (dev/staging/prod) before running. Never deploy to a production instance the operator has not approved. |
 | `powersync destroy --confirm=yes` | Permanently destroys the linked Cloud instance | Always require explicit, in-conversation confirmation naming the instance. Treat as one-shot authorization. |
 | `powersync stop --confirm=yes` | Stops the linked Cloud instance (clients lose sync) | Same as `destroy` — confirm instance and that the operator accepts downtime. |
+| `powersync compact` | Triggers bucket compacting on the linked Cloud instance; polls until complete | Confirm Cloud instance id and environment before running. Default 30-min timeout; pass `--timeout=<minutes>` to override, or `--timeout=0` to wait indefinitely. |
 | `powersync link cloud --create` | Creates a new Cloud instance | Only during initial bootstrap. Do not run on a project that already has a linked instance unless the operator explicitly wants a second one. |
 | `powersync pull instance` | Overwrites local `service.yaml` and `sync-config.yaml` from the remote | Back up local files first. Do not run after local edits unless the operator accepts losing them. |
 
@@ -102,7 +103,7 @@ For Cloud, `--org-id` / `ORG_ID` is optional — omit it when your token has acc
 | Hosting | How the CLI authenticates |
 |---------|---------------------------|
 | **PowerSync Cloud** | `PS_ADMIN_TOKEN` (PAT) or token from **`powersync login`** |
-| **Self-hosted** | No `powersync login` for the running service. Use **`powersync init self-hosted`**, **`powersync docker configure` / `powersync docker start`**, and **`PS_ADMIN_TOKEN`** matching the self-hosted service’s admin API token (see self-hosted docs). |
+| **Self-hosted** | No `powersync login` for the running service. Use **`powersync init self-hosted`**, **`powersync docker configure` / `powersync docker start`**, and **`PS_ADMIN_TOKEN`** matching the self-hosted service's admin API token (see self-hosted docs). |
 
 Do not tell the operator to run `powersync login` when they are **only** using a local self-hosted stack unless they also need Cloud CLI commands.
 
@@ -141,7 +142,7 @@ Self-hosted instances use `PS_ADMIN_TOKEN` as the API key (not accepted via flag
 Define your instance and sync config in YAML files so you can version them in git, review changes before deploying, and run `powersync validate` before `powersync deploy`. The CLI uses a config directory (default `powersync/`) containing:
 
 | File | Purpose |
-|------|---------|
+|------|--------|
 | `service.yaml` | Instance configuration: name, region, replication DB connection, client auth |
 | `sync-config.yaml` | Sync Streams (or Sync Rules) configuration |
 | `cli.yaml` | Link file (written by `powersync link`); ties this directory to an instance |
@@ -514,7 +515,7 @@ Keep `service.yaml` and `sync-config.yaml` in the repo (with secrets via `!env` 
 Required CI environment variables:
 
 | Variable | Purpose |
-|----------|---------|
+|----------|--------|
 | `PS_ADMIN_TOKEN` | PowerSync personal access token |
 | `INSTANCE_ID` | Target instance (if not using a linked directory) |
 | `PROJECT_ID` | Target project (if not using a linked directory) |
@@ -531,7 +532,7 @@ powersync deploy sync-config
 
 ## Common Commands
 
-> **Mutating commands** (`deploy`, `destroy`, `stop`, `link --create`, `pull instance`) require an instance + scope check before running — see "Mutating Commands — Confirm Before Running" above.
+> **Mutating commands** (`deploy`, `destroy`, `stop`, `compact`, `link --create`, `pull instance`) require an instance + scope check before running — see "Mutating Commands — Confirm Before Running" above.
 
 | Command | Description |
 |---------|-------------|
@@ -557,6 +558,7 @@ powersync deploy sync-config
 | `powersync generate token --subject=user-123` | Generate a development JWT (see Development Tokens below) |
 | `powersync destroy --confirm=yes` | [Cloud only] Permanently destroy the linked instance |
 | `powersync stop --confirm=yes` | [Cloud only] Stop the linked instance (restart with deploy) |
+| `powersync compact` | [Cloud only] Trigger bucket compacting on demand; polls until complete (default 30-min timeout). Pass `--timeout=<minutes>` to override, or `--timeout=0` to wait indefinitely. |
 
 For full usage and flags, run `powersync --help` or `powersync <command> --help`.
 
@@ -586,7 +588,7 @@ npm install -g @powersync/cli@0.8.0
 Otherwise, upgrade to the latest `powersync` package and follow this mapping:
 
 | Previous CLI | New CLI |
-|-------------|---------|
+|-------------|--------|
 | `npx powersync init` (enter token, org, project) | `powersync login` (token only). Then `powersync init cloud` to scaffold, or `powersync pull instance --project-id=... --instance-id=...` to pull an existing instance. |
 | `powersync instance set --instanceId=<id>` | `powersync link cloud --instance-id=<id> --project-id=<id>` (writes `cli.yaml`). Use `--directory` for a specific folder. |
 | `powersync instance deploy` (interactive or long flag list) | Edit `powersync/service.yaml` and `powersync/sync-config.yaml`, then `powersync deploy`. Config is in files, not command args. |


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._\n\n**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/463\n\n### What changed in docs\n\nDocumented `powersync compact` as a new Cloud-only CLI command that triggers on-demand bucket compacting. The command polls until the operation completes, with a default 30-minute timeout and `--timeout=<minutes>` / `--timeout=0` flags.\n\n### Skill updates in this PR\n\n- `skills/powersync/references/powersync-cli.md` — added `powersync compact` row to the Mutating Commands table (with timeout flags documented) and to the Common Commands table (marked `[Cloud only]`); updated the Common Commands section header note to include `compact` in the list of commands requiring an instance check.\n- `skills/powersync/AGENTS.md` — added `compact` to the mutating commands list in the \"Confirm the target instance before any mutating command\" section.\n\n### Notes for reviewer\n\n- `powersync compact` is Cloud-only and does not apply to self-hosted instances (consistent with how `destroy` and `stop` are scoped in the existing files).\n- Classified as a mutating command because it triggers a state-changing operation on the Cloud instance; it was added to AGENTS.md's list so agents confirm the target instance before running it. If the team considers it lower-risk than `deploy`/`destroy` and prefers it stay out of the mutating list, that's a reasonable call — the Common Commands table entry alone would still document its existence.\n- The docs note compacting also remains available via the Dashboard; no skill changes were needed for that path as it was already documented."

---
_Generated by [Claude Code](https://claude.ai/code/session_014kW3CyvVKMg9AejXSVV5qW)_