### PR TITLE
Sync from docs: remove OPFS CORS header requirement for Safari (powersync-docs #474)

### DIFF
--- a/skills/powersync/references/sdks/powersync-dart.md
+++ b/skills/powersync/references/sdks/powersync-dart.md
@@ -191,4 +191,10 @@ PowerSync supports [Drift](https://pub.dev/packages/drift) as an ORM via [drift_
 
 ## Flutter Web
 
-Supported in `powersync` v1.9.0+. See [Flutter Web Support](https://docs.powersync.com/client-sdks/frameworks/flutter-web-support.md) for configuration requirements, OPFS setup for improved performance, and known limitations.
+Supported in `powersync` v1.9.0+.
+
+- If using SDK 2.2.0+: OPFS is supported on all major browsers (Chrome, Firefox, and Safari) without additional server headers. The SDK auto-selects OPFS when available, falling back to IndexedDB on older browsers or Safari private browsing.
+- If using SDK <2.2.0: enabling OPFS on Safari requires serving the app with `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` response headers.
+- If upgrading to 2.2.0 from an older version that used those CORS headers: remove the headers from your server. Existing OPFS databases in Safari continue to work; users who had IndexedDB databases keep them with no data loss.
+
+See [Flutter Web Support](https://docs.powersync.com/client-sdks/frameworks/flutter-web-support.md) for full setup details and known limitations.


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/474

### What changed in docs

Starting with Dart/Flutter SDK 2.2.0, OPFS is supported on all major browsers (Chrome, Firefox, and Safari) without requiring special `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy` server headers. The docs removed the header instructions and added a migration note for existing users.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-dart.md` — Replaced the single-line Flutter Web pointer (which implied OPFS requires additional configuration) with version-conditional rules: SDK 2.2.0+ needs no headers; SDK <2.2.0 still does; upgrading users can safely remove the headers with no data loss.

### Notes for reviewer

- The existing skill had only a one-liner pointing to external docs. The updated text surfaces the version-conditional behaviour directly so an agent doesn't tell a 2.2.0+ user to add CORS headers that are no longer needed.
- The DevTools button label change (`Open in Diagnostics App` → `Open in Sync Diagnostics Client`) in the docs PR has no skill counterpart and no agent-decision impact; intentionally left untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYXDv1GmETtuWAqwgmwNok)_