### PR TITLE
Sync from docs: rename log type and add dashboard search syntax (powersync-docs #462)

### DIFF
--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -203,12 +203,12 @@ For source-specific guidance (Postgres, MongoDB, MySQL, SQL Server) see [Replica
 
 ### Stage 2: PowerSync Service to Client
 
-Service/API logs record two events per sync session:
+Sync & API logs record two events per sync session:
 
 - **Sync stream started** — logged when the client connects. Fields: `user_id`, `client_id`, `app_metadata` (if set), `client_params`, `user_agent`, `rid` (request ID).
 - **Sync stream complete** — logged when the session ends. Fields: `user_id`, `client_id`, `app_metadata` (if set), `operations_synced`, `operation_counts` (`put`, `remove`, `move`, `clear`), `data_synced_bytes`, `data_sent_bytes`, `stream_ms` (session duration), `close_reason`, `rid`.
 
-Both events share the same `rid`, so a started/complete pair can be matched by filtering on it. To find a specific user's sessions, filter on `user_id`.
+Both events share the same `rid`; to match a started/complete pair for a single session, search `rid:<request-id>` in the dashboard **Logs** view. To find a specific user's sessions, search `user_id:<user-id>`.
 
 [Custom metadata](https://docs.powersync.com/maintenance-ops/monitoring-and-alerting#custom-metadata-in-sync-logs) set at `connect()` time appears in both events, enabling filtering by app version, environment, or other context.
 


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/462

### What changed in docs

The dashboard log section was expanded: the log type was renamed from "Service/API logs" to "Sync & API logs", and a structured search grammar was documented for filtering by `user_id`, `rid`, `error`, `close_reason`, and other properties, plus a CSV export feature.

### Skill updates in this PR

- `skills/powersync/references/powersync-debug.md` — updated "Stage 2: PowerSync Service to Client" to use the renamed log type ("Sync & API logs") and replaced vague "filter on `user_id`" / "filter on it" instructions with the actual dashboard search syntax (`user_id:<user-id>`, `rid:<request-id>`).

### Notes for reviewer

- The docs PR documents a full search grammar (free-text, `alias:value` filters, numeric comparisons for `lag`, property filter chips, CSV export). Only the pieces an agent would use when guiding a user through session correlation have been added to the skill. The rest (export, chip editing, rate-limit note, full alias table) is dashboard UI detail that doesn't require agent-side awareness — left out intentionally.
- If a `powersync-monitoring.md` or similar reference file is ever added for dashboard operations, the full search grammar would be a good candidate to surface there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBqzhE49fnhtAkygoP6jFj)_