### PR TITLE
Sync from docs: mark Capacitor SDK as beta (powersync-docs #477)

### DIFF
--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -52,11 +52,11 @@ Framework-specific files (load alongside this file):
 ## Package Coverage
 
 | Need | Package |
-|------|---------|
+|------|--------|
 | Web browser | `@powersync/web` |
 | React Native | `@powersync/react-native` |
 | Node.js/CLI | `@powersync/node` |
-| Capacitor | `@powersync/capacitor` |
+| Capacitor (beta) | `@powersync/capacitor` |
 | React hooks | `@powersync/react` |
 | Vue composables | `@powersync/vue` |
 | Nuxt module | `@powersync/nuxt` |
@@ -689,7 +689,7 @@ subscription.unsubscribe();
 These advanced topics are in separate files — load only when needed:
 
 | Topic | File | Load when… |
-|-------|------|-----------|
+|-------|------|----------|
 | Drizzle / Kysely ORM | `references/sdks/powersync-js-orm.md` | Using Drizzle or Kysely for type-safe queries |
 | Raw Tables | `references/raw-tables.md` | Need native SQLite tables (SDK-agnostic — JS, Dart, Kotlin, Swift, Rust) |
 


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/477

### What changed in docs

The Capacitor SDK was promoted from alpha to beta across all docs pages, with the stability language updated to reflect that the SDK is production-ready for tested use cases (the Capacitor Community SQLite driver portion is no longer described as experimental).

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-js.md` — Updated the Package Coverage table to label the Capacitor entry as `(beta)`, reflecting its promoted maturity status.

### Notes for reviewer

- No existing skill file contained an explicit "alpha" label for Capacitor, so there is no incorrect text to correct — only the maturity annotation in the Package Coverage table was missing.
- There is no dedicated `powersync-js-capacitor.md` reference file, and Capacitor does not appear in the SKILL.md JS/TS SDK framework table. Now that the SDK is beta, a dedicated reference file (covering Capacitor-specific setup, the `@capacitor-community/sqlite` driver, and known limitations) may be worth adding. Flagging as a gap for the reviewer to decide.
- The docs also updated the warning text to clarify that the Web SDK–derived functionality is stable while the SQLite driver portion is "production-ready for tested use cases." This nuance is not reflected in the current skill; the reviewer may want to add a note about known limitations in a future Capacitor reference file.

---
_Generated by [Claude Code](https://claude.ai/code/session_016nH97YeR7m73qkaNcLLBmQ)_