### PR TITLE
Sync from docs: document composite-key JOIN support in Sync Streams (powersync-docs #395)

### DIFF
--- a/skills/powersync/references/sync-config.md
+++ b/skills/powersync/references/sync-config.md
@@ -218,6 +218,19 @@ streams:
       WHERE tm.user_id = auth.user_id()
 ```
 
+For composite-key joins (multiple join columns), use implicit join syntax with multiple `WHERE` equality conditions:
+
+```yaml
+streams:
+  regional_comments:
+    query: |
+      SELECT comments.*
+      FROM comments, issues
+      WHERE comments.issue_id = issues.id
+        AND comments.region = issues.region
+        AND issues.user_id = auth.user_id()
+```
+
 ### Subquery
 
 Use `WHERE id IN (SELECT ...)` for indirect access through a related table:
@@ -397,7 +410,7 @@ There are examples available for each PowerSync Client SDK.
 ### Frameworks 
 
 | Framework                 | Client Usage Reference URL                                                                                         |
-|---------------------------|--------------------------------------------------------------------------------------------------------------------|
+|---------------------------|-----------------------------------------------------------------------------------------------------------------|
 | React                     | [Client Usage](https://docs.powersync.com/sync/streams/client-usage.md#react-hooks)                                        |
 
 ## Advanced Topics


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/395

### What changed in docs

The Sync Streams compiler now supports joining two tables on multiple columns (composite keys) — queries that previously failed with an internal circular reference error are now valid. The docs added a composite-key example to the JOIN Syntax reference in `sync/supported-sql.mdx`.

### Skill updates in this PR

- `skills/powersync/references/sync-config.md` — added a composite-key JOIN example under the `### JOIN` common pattern, showing implicit join syntax with multiple `WHERE` equality conditions.

### Notes for reviewer

The docs PR also mentions a "Multi-column join conditions" subsection was added to the Writing Queries page, but the diff only touched `sync/supported-sql.mdx` (6 additions, 1 file). The skill edit mirrors what is in the diff: a valid composite-key example. If the Writing Queries page change surfaces in a follow-up docs PR, a further skill update may be warranted.

---
_Generated by [Claude Code](https://claude.ai/code/session_014fvKj11EcaNrmMUCx3mJuT)_