### PR TITLE
Sync from docs: document test-client --env flag for !env PS_* configs (powersync-docs #469)

### DIFF
--- a/skills/powersync/references/powersync-cli.md
+++ b/skills/powersync/references/powersync-cli.md
@@ -577,6 +577,12 @@ powersync generate token --subject=user-test-1
 
 Dev tokens are for development only. In production, `fetchCredentials()` must return a real JWT from your auth provider.
 
+**Test-client (`@powersync/service-test-client`):** If using `node dist/bin.js generate-token` instead of the CLI, and your `service.yaml` uses `!env PS_*` tags, the test-client reads those values from your shell by default. To load them from a dotenv file instead, pass `--env`:
+
+```bash
+node dist/bin.js generate-token --config path/to/service.yaml --env path/to/.env --sub test-user
+```
+
 ## Migrating from the Previous CLI (0.8.0 → 0.9.0)
 
 Version 0.9.0 is not backwards compatible with 0.8.0. To stay on the old CLI:


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/469

### What changed in docs

The docs PR clarifies that when the test-client (`@powersync/service-test-client`) encounters `!env PS_*` tags in a `service.yaml` config, it reads those values from the shell by default. A new `--env path/to/.env` flag was documented to allow loading them from a file instead, with an example command added for `generate-token`.

### Skill updates in this PR

- `skills/powersync/references/powersync-cli.md` — added a "Test-client" note under the Development Tokens section documenting the `--env` flag behaviour when `service.yaml` uses `!env PS_*` tags.

### Notes for reviewer

- The test-client (`node dist/bin.js`) is distinct from the `powersync` CLI (`powersync generate token`). It is not currently documented anywhere in agent-skills beyond this new note. If agents are expected to guide developers through test-client workflows more broadly (e.g. `fetch-operations`), a dedicated section or reference file for `@powersync/service-test-client` may be warranted — left as a gap for maintainer judgement.
- The docs change also appears in a usage-and-billing FAQ context (`fetch-operations` command). No skill currently covers that command; the added note in `powersync-cli.md` covers the core `!env`/`--env` behaviour pattern shared by both commands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G79n5y23onV71mMYvLM29U)_