### PR TITLE
Sync from docs: clarify Private Endpoint vs Endpoint Service region requirements (powersync-docs #496)

### DIFF
--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -260,7 +260,7 @@ Private Endpoints use AWS PrivateLink for private networking between your source
 **Setup flow:**
 
 1. **Configure an Endpoint Service** in front of your source database and copy its **Service Name** (`com.amazonaws.vpce.<region>.vpce-svc-<id>`):
-   - *MongoDB Atlas*: Security → Database & Network Access → Network Access → Private Endpoint → Dedicated Cluster → Create endpoint service. Select the Atlas region matching your PowerSync cluster and the PowerSync AWS region under Accepted Endpoint Regions.
+   - *MongoDB Atlas*: Security → Database & Network Access → Network Access → Private Endpoint → Dedicated Cluster → Create endpoint service. The Atlas cluster does not need to be in the same region as the PowerSync instance; add the PowerSync AWS region under Accepted Endpoint Regions so Atlas accepts connections from it.
    - *Custom Postgres*: Create a Target Group (IP type, TCP, port 5432) → Network Load Balancer → VPC Endpoint Service. Allow principal `arn:aws:iam::131569880293:root` to connect.
 2. **Create the Private Endpoint in the Dashboard**: Dashboard → Organization Settings → Private Endpoints → Create. Provide a name, the Service Name from step 1, and the PowerSync region matching your instance. The endpoint starts in `Pending Acceptance` state.
 3. **Copy the VPC Endpoint ID** (`vpce-<id>`) from the Dashboard and accept the connection on the Endpoint Service:
@@ -269,7 +269,7 @@ Private Endpoints use AWS PrivateLink for private networking between your source
 4. **Wait for `Available`** status in the Dashboard:
 
 | Status | Meaning |
-|--------|---------|
+|--------|-------|
 | `Pending acceptance` | Waiting for you to accept the connection on the Endpoint Service. |
 | `Pending` | Being provisioned. |
 | `Available` | Ready to use. |
@@ -278,7 +278,7 @@ Private Endpoints use AWS PrivateLink for private networking between your source
 
 5. **Connect using the Private Endpoint**: Instance → Database Connections → select the endpoint in the Private Endpoint dropdown (only `Available` endpoints in the same region are selectable). For MongoDB Atlas, use the connection string from the Atlas Connect dialog with Private Endpoint selected as the connection type.
 
-**AWS regions supported:** `us-east-1`, `eu-west-1`, `sa-east-1`, `ap-northeast-1`, `ap-southeast-2`. The Private Endpoint must be in the same region as the PowerSync instance.
+**AWS regions supported:** `us-east-1`, `eu-west-1`, `sa-east-1`, `ap-northeast-1`, `ap-southeast-2`. The Private Endpoint must be in the same region as the PowerSync instance; the Endpoint Service itself can be in any AWS region, as long as it accepts connections from the PowerSync instance's region.
 
 ## Source Database Setup
 


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/496

### What changed in docs

The private endpoints page was updated to clarify that only the **Private Endpoint** (created in the dashboard) must match the region of the PowerSync instance — the underlying **AWS PrivateLink Endpoint Service** can be in any AWS region, as long as it accepts connections from the PowerSync instance's region.

### Skill updates in this PR

- `skills/powersync/references/powersync-service.md` — Updated the MongoDB Atlas Endpoint Service setup step to remove the implied requirement that the Atlas cluster must be in the same region as the PowerSync instance (it doesn't; it just needs the PowerSync AWS region added under Accepted Endpoint Regions). Updated the "AWS regions supported" note to state explicitly that the Endpoint Service can be in any region, while the Private Endpoint must still match the PowerSync instance's region.

### Notes for reviewer

- The docs PR removed a note ("A Private Endpoint can only be used by PowerSync instances in the same region. Endpoints in other regions will not appear in the connection form.") that described the Private Endpoint's region constraint from the user's perspective. The skill never contained that exact note, but the MongoDB Atlas step previously implied the Atlas cluster itself had to match the PowerSync region — corrected here.
- No new skill file warranted; this is a targeted clarification within the existing Private Endpoints section of `powersync-service.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkvszF3nuMBjeuQ6DF1koe)_