### PR TITLE
Sync from docs: add Terraform provider reference (powersync-docs #494)

### DIFF
--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -107,6 +107,7 @@ These apply to all paths. Domain-specific pitfalls are in their reference files 
 
 Additional footguns by area (do not load unless working there):
 - **Config/CLI:** `references/powersync-cli.md`, `references/powersync-service.md`, `references/sync-config.md`
+- **Terraform/IaC:** `references/terraform.md` (credential handling, `sync_config_content` wrapper, do not mix CLI deploys with Terraform-managed instances)
 - **JS/TS SDK:** `references/sdks/powersync-js.md` (type-only imports, `connect()` semantics, `transaction.complete()`)
 - **React:** `references/sdks/powersync-js-react.md` (Strict Mode, Suspense, Next.js)
 - **Supabase:** `references/supabase-auth.md` (JWT signing keys, publication SQL, local Supabase)
@@ -187,6 +188,10 @@ Load `references/powersync-cli.md`, `references/powersync-service.md`, and `refe
 ### Path 4: Self-Hosted + Manual Docker
 
 Only when the CLI cannot be used. Load `references/powersync-service.md` and `references/sync-config.md`. Backend not Supabase? Also load `references/custom-backend.md`.
+
+### Path 5: Cloud + Terraform (IaC)
+
+If the operator is managing PowerSync Cloud alongside other infrastructure in Terraform, load `references/terraform.md`. The Terraform provider provisions projects and instances and deploys sync config — do not also run `powersync deploy` against the same instance. Auth uses `PS_PAT_TOKEN` (not `PS_ADMIN_TOKEN`). `sync_config_content` on the `powersync_instance` resource follows the same Sync Streams format as `sync-config.yaml` — load `references/sync-config.md` for the full reference.
 
 ## Architecture, Routing, SDK Tables & Key Rules
 

--- a/skills/powersync/SKILL.md
+++ b/skills/powersync/SKILL.md
@@ -42,6 +42,7 @@ If a sentence is ambiguous, default to the operator interpretation. Full legend 
 | Custom backend (non-Supabase) | `references/onboarding-custom.md` | `references/custom-backend.md`, `references/sync-config.md`, SDK files |
 | New project setup | `references/powersync-cli.md` + `references/powersync-service.md` | `references/sync-config.md`, SDK files |
 | Self-hosting / service config | `references/powersync-service.md` + `references/powersync-cli.md` | `references/sync-config.md` |
+| Terraform / IaC provisioning | `references/terraform.md` | `references/sync-config.md`, `references/supabase-auth.md` (if Supabase source) |
 | Writing sync config | `references/sync-config.md` | — |
 | Debugging sync issues | `references/powersync-debug.md` | — |
 | Raw Tables (advanced) | `references/raw-tables.md` | — |

--- a/skills/powersync/references/terraform.md
+++ b/skills/powersync/references/terraform.md
@@ -1,0 +1,153 @@
+---
+name: powersync-terraform
+description: PowerSync Terraform provider — provisioning and managing PowerSync Cloud projects and instances as infrastructure-as-code
+metadata:
+  tags: terraform, iac, infrastructure-as-code, powersync, cloud, powersync_project, powersync_instance, powersync_organization, PS_PAT_TOKEN, hcl, provisioning
+---
+
+# PowerSync Terraform Provider
+
+> **Load this when** the operator is using Terraform to provision or manage PowerSync Cloud infrastructure, or asks about managing PowerSync via IaC. This covers Cloud only — for self-hosted deployments, use `references/powersync-service.md` and `references/powersync-cli.md`.
+
+Provider source: `powersync-ja/powersync` on the [Terraform Registry](https://registry.terraform.io/providers/powersync-ja/powersync/latest/docs). Minimum Terraform version: 1.5.
+
+## When to Use Terraform vs the CLI
+
+- If the operator is managing PowerSync alongside other cloud resources (databases, networking, compute) in Terraform, use the Terraform provider — it provisions the PowerSync project and instance in the same `terraform apply`.
+- If the operator needs IaC-reviewable config (plan diffs in PRs), multi-environment parity, or version-controlled infrastructure, prefer Terraform.
+- If the operator is working interactively or only needs to deploy sync config, prefer the PowerSync CLI (`references/powersync-cli.md`).
+- Terraform manages the project and instance lifecycle; `sync_config_content` on the instance resource replaces `powersync deploy sync-config`. You do not run the CLI alongside Terraform for the same instance.
+
+## Authentication
+
+The provider authenticates via a personal access token. Set it as an environment variable before any `terraform` command:
+
+```sh
+export PS_PAT_TOKEN="jpt_..."
+```
+
+The provider reads `PS_PAT_TOKEN` automatically — do not inline the token in HCL. Direct operators who need a token to: **Dashboard → Account → Access Tokens**.
+
+## Provider Declaration
+
+```hcl
+terraform {
+  required_providers {
+    powersync = {
+      source  = "powersync-ja/powersync"
+      version = "~> 0.1"
+    }
+  }
+}
+
+provider "powersync" {
+  # Reads PS_PAT_TOKEN from env automatically.
+  # admin_token = var.admin_token  # only if env var is not viable
+}
+```
+
+Run `terraform init` to download the provider binary.
+
+## Organization
+
+Organizations are not Terraform-managed resources — they exist when you sign up. Use a data source to reference one:
+
+```hcl
+data "powersync_organization" "main" {
+  id = "<org-id>"   # hex segment from the dashboard URL: /orgs/<id>/
+}
+```
+
+## Project Resource
+
+```hcl
+resource "powersync_project" "main" {
+  org_id = data.powersync_organization.main.id
+  name   = "my-project"
+  region = "us"   # supported: eu, us, jp, au, br
+}
+```
+
+If `force_destroy = true` is not set and the project contains instances created outside Terraform, `terraform destroy` will fail. Set `force_destroy = true` on the project resource to override this safety check.
+
+## Instance Resource
+
+`powersync_instance` wires together replication, client auth, and sync config:
+
+```hcl
+variable "replication_password" {
+  type      = string
+  sensitive = true
+}
+
+resource "powersync_instance" "main" {
+  org_id     = data.powersync_organization.main.id
+  project_id = powersync_project.main.id
+  name       = "production"
+
+  replication_connection {
+    type     = "postgresql"
+    name     = "main"
+    hostname = "db.<project-ref>.supabase.co"
+    port     = 5432
+    username = "powersync_role"
+    password = var.replication_password
+    database = "postgres"
+    sslmode  = "verify-full"
+  }
+
+  client_auth {
+    supabase               = true
+    allow_temporary_tokens = true
+  }
+
+  sync_config_content = <<-YAML
+    config:
+      edition: 3
+    streams:
+      todos:
+        auto_subscribe: true
+        query: SELECT * FROM todos WHERE user_id = auth.user_id()
+  YAML
+}
+```
+
+Pass `replication_password` (and any other sensitive values) via environment variable — never in plaintext config or state:
+
+```sh
+export TF_VAR_replication_password="..."
+terraform plan
+terraform apply
+```
+
+## sync_config_content
+
+`sync_config_content` is a Sync Streams YAML string. It must start with `config: edition: 3`. For non-trivial configs, load from a file:
+
+```hcl
+sync_config_content = file("${path.module}/sync-config.yaml")
+```
+
+For the full Sync Streams reference, load `references/sync-config.md`.
+
+## Managing Changes
+
+- To update any field, edit the HCL and re-run `terraform plan` then `terraform apply`.
+- Every change to `powersync_instance` triggers a full redeploy. The instance ID and URL remain the same.
+- `terraform show` displays the full resource state including the instance URL after apply.
+
+## Destroying Resources
+
+```sh
+terraform destroy
+```
+
+- Removes the instance and the project.
+- If the project contains instances not tracked by this Terraform state, destroy fails unless `force_destroy = true` is set on `powersync_project`.
+
+## Critical Pitfalls
+
+- Never inline credentials in HCL or state. Use `TF_VAR_*` environment variables for sensitive Terraform variables.
+- `sync_config_content` must include the `config: edition: 3` wrapper — the same requirement as `sync-config.yaml` for the CLI. Missing this wrapper causes validation/deploy failures.
+- Terraform manages the full instance lifecycle. Do not mix CLI deploys (`powersync deploy`) against the same instance managed by Terraform — the two tools will overwrite each other's changes.
+- For Supabase source databases, the Supabase publication and `powersync_role` still need to be configured separately (Terraform does not manage source-DB-side replication setup). See `references/supabase-auth.md`.


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/494

### What changed in docs

powersync-docs #494 added a complete Terraform provider page (`tools/terraform.mdx`) covering the `powersync-ja/powersync` Terraform provider — authentication via `PS_PAT_TOKEN`, the `powersync_organization` data source, `powersync_project` and `powersync_instance` resources, `sync_config_content` format, supported regions, and teardown behaviour. The tools overview page was also updated to surface the new provider.

### Skill updates in this PR

- `skills/powersync/references/terraform.md` — new reference file: when to use Terraform vs CLI, auth, provider declaration, key resources and their fields, `sync_config_content` requirements, managing changes, teardown, and critical pitfalls (credential handling, no mixed CLI/Terraform, sync_config_content `edition: 3` wrapper)
- `skills/powersync/AGENTS.md` — added "Path 5: Cloud + Terraform (IaC)" to Setup Paths; added Terraform entry to "Additional footguns by area"
- `skills/powersync/SKILL.md` — added "Terraform / IaC provisioning" row to the "What to Load for Your Task" routing table

### Notes for reviewer

- The Terraform provider covers **PowerSync Cloud only** — self-hosted is explicitly out of scope in the docs. The skill mirrors this.
- Auth token name differs from the CLI: `PS_PAT_TOKEN` (not `PS_ADMIN_TOKEN`). Both refer to the same personal access token value, just different env var names recognised by different tools. This distinction is called out in the new reference file and in Path 5 of AGENTS.md.
- The docs do not yet cover multi-environment patterns for Terraform (separate workspaces/modules for dev/staging/prod). This is a gap worth a follow-up if the provider docs expand in that direction.
- `sync_config_content` on `powersync_instance` replaces `powersync deploy sync-config` for Terraform-managed instances. The critical rule against mixing the two tools is included in terraform.md and the AGENTS.md footgun entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XCpkYsGvEApgFncv9iUdS)_