### PR TITLE
Sync from docs: add unstable_sqlite_expression_engine compatibility flag (powersync-docs #485)

### DIFF
--- a/skills/powersync/references/sync-config.md
+++ b/skills/powersync/references/sync-config.md
@@ -425,6 +425,7 @@ Reference these when the standard patterns don't cover your use case:
 | [Multiple Client Versions](https://docs.powersync.com/sync/advanced/multiple-client-versions.md) | Support different schema versions across app releases |
 | [Partitioned Tables](https://docs.powersync.com/sync/advanced/partitioned-tables.md) | Sync from Postgres partitioned tables |
 | [Sharded Databases](https://docs.powersync.com/sync/advanced/sharded-databases.md) | Source data from multiple database shards |
+| [Compatibility Flags](https://docs.powersync.com/sync/advanced/compatibility) | Fix known SQL expression edge cases in Sync Streams; if `NOT NULL`, `substr()`, or `length()` behave unexpectedly, `unstable_sqlite_expression_engine` (Service ≥ 1.22.0, experimental — may be removed) routes evaluation through actual SQLite |
 
 # Sync Rules (Legacy, use Sync Streams for new applications)
 


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/485

### What changed in docs

PowerSync Service 1.22.0 introduced the `unstable_sqlite_expression_engine` compatibility flag, which routes Sync Stream SQL expression evaluation through an actual SQLite database instead of the custom JS evaluator — fixing known edge cases in `NOT NULL` handling and `substr()`/`length()` Unicode semantics. The flag is explicitly experimental and may be removed in a future Service release.

### Skill updates in this PR

- `skills/powersync/references/sync-config.md` — Added `Compatibility Flags` row to the Advanced Topics table, linking to the compatibility docs and describing when to reach for `unstable_sqlite_expression_engine` (Service ≥ 1.22.0, experimental) as a fix for SQL expression edge cases.

### Notes for reviewer

- The docs page does not show the YAML configuration syntax for enabling compatibility flags (i.e. which key in `service.yaml` or `sync-config.yaml` activates them). If that syntax exists and is documented elsewhere, it may be worth adding a snippet to `powersync-service.md` or `sync-config.md` as a follow-up.
- `unstable_sqlite_expression_engine` is marked unstable/experimental in the docs — the skill entry reflects this with the "experimental — may be removed" qualifier so agents surface the caveat when recommending it.
- No new skill file was created; the Advanced Topics table entry is sufficient to make the flag discoverable from the sync config skill.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Cim2jRRjKixExCDYB6nBF)_