### PR TITLE
Sync from docs: rename Metrics→Monitoring and Telemetry→Usage Reporting (powersync-docs #499)

### DIFF
--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -217,7 +217,7 @@ Prometheus metrics are exposed on port `9464`. Enable the chart's `NetworkPolicy
 | `powersync_operation_storage_size_bytes` | Capacity-plan from the trend. |
 | `powersync_data_sent_bytes_total` | Egress cost driver. |
 
-See [Metrics](https://docs.powersync.com/maintenance-ops/self-hosting/metrics) for the full metric catalog.
+See [Usage Reporting](https://docs.powersync.com/maintenance-ops/self-hosting/usage-reporting#whatiscollected) for the full metric catalog.
 
 ### Bucket Storage Database
 This is required by PowerSync and can be configured in two different ways. This is separate from the source DB.


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._\n\n**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/499\n\n### What changed in docs\n\nThe self-hosted docs pages previously titled \"Metrics\" and \"Telemetry\" were renamed to \"Monitoring\" (`/maintenance-ops/self-hosting/monitoring`) and \"Usage Reporting\" (`/maintenance-ops/self-hosting/usage-reporting`) respectively, with redirects added for the old URLs. Wording in several pages was updated to reflect the new framing.\n\n### Skill updates in this PR\n\n- `skills/powersync/references/powersync-service.md` — Updated the stale `[Metrics](…/metrics)` link in the Kubernetes Observability section to `[Usage Reporting](…/usage-reporting#whatiscollected)`, matching the updated destination in the docs (the \"What is Collected\" section on the Usage Reporting page is the actual metric catalog).\n\n### Notes for reviewer\n\n- The old `/maintenance-ops/self-hosting/metrics` URL still resolves via a redirect, so the skill was not actively broken — but the link text and destination are now misleading. The fix aligns with the updated anchor used in `aws-eks.mdx` in the docs PR.\n- No other skill files contain references to the old `telemetry` or `metrics` page paths.\n- The docs PR also clarified that the \"Telemetry\" page (now \"Usage Reporting\") covers anonymous usage metrics sent to PowerSync, not general OpenTelemetry observability. No skill content describes this concept directly, so no further wording changes were needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0113CNg1jVkszhmZxbx7qpGU)_