### PR TITLE
Sync from docs: add log search exclusion syntax to debug reference (powersync-docs #507)

### DIFF
--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -216,7 +216,7 @@ Sync & API logs record two events per sync session:
 - **Sync stream started** — logged when the client connects. Fields: `user_id`, `client_id`, `app_metadata` (if set), `client_params`, `user_agent`, `rid` (request ID).
 - **Sync stream complete** — logged when the session ends. Fields: `user_id`, `client_id`, `app_metadata` (if set), `operations_synced`, `operation_counts` (`put`, `remove`, `move`, `clear`), `data_synced_bytes`, `data_sent_bytes`, `stream_ms` (session duration), `close_reason`, `rid`.
 
-Both events share the same `rid`; to match a started/complete pair for a single session, search `rid:<request-id>` in the dashboard **Logs** view. To find a specific user's sessions, search `user_id:<user-id>`.
+Both events share the same `rid`; to match a started/complete pair for a single session, search `rid:<request-id>` in the dashboard **Logs** view. To find a specific user's sessions, search `user_id:<user-id>`. If a known error is producing noise, prefix the filter with `-` to exclude matching entries. For example, `-error:PSYNC_S2106` hides all entries with that error code.
 
 [Custom metadata](https://docs.powersync.com/maintenance-ops/monitoring-and-alerting#custom-metadata-in-sync-logs) set at `connect()` time appears in both events, enabling filtering by app version, environment, or other context.
 


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/507

### What changed in docs

The monitoring-and-alerting page documents a new `-` exclusion prefix for the dashboard Logs view search, along with two minor UI additions (clicking a timestamp to set the time range, hovering an entry to copy it as JSON).

### Skill updates in this PR

- `skills/powersync/references/powersync-debug.md`: Added two sentences to the Stage 2 log search paragraph documenting the `-` exclusion prefix. The existing skill already references `rid:` and `user_id:` search syntax in that section; the exclusion syntax extends the same capability.

### Notes for reviewer

The timestamp-click and hover-to-copy-JSON features from the docs PR were omitted. They are UI interactions that don't affect the search queries an agent would suggest, so they don't warrant skill updates.

---
_Generated by [Claude Code](https://claude.ai/code/session_012jwJ3iXq711hGxpKCfYKAU)_