### PR TITLE
Sync from docs: put * before column aliases in Sync Streams queries (powersync-docs #517)

### DIFF
--- a/skills/powersync/references/sync-config.md
+++ b/skills/powersync/references/sync-config.md
@@ -259,6 +259,21 @@ streams:
         AND list_id IN (SELECT id FROM lists WHERE owner_id = auth.user_id())
 ```
 
+### ID Column Aliasing
+
+If a source table uses a different primary key name (e.g. MongoDB uses `_id`), alias it to `id` in the query. When the query also selects `*`, write `*` before the alias. The last column with a given name wins; if `*` comes after the alias and the source table has a column with the same name, `*` silently overwrites the alias.
+
+```yaml
+streams:
+  lists:
+    auto_subscribe: true
+    queries:
+      - SELECT *, _id as id FROM lists
+      - SELECT *, _id as id FROM todos WHERE archived = false
+```
+
+The same rule applies to composite IDs, e.g. `SELECT *, item_id || '.' || category_id as id FROM item_categories`.
+
 See [Writing Queries](https://docs.powersync.com/sync/streams/queries.md) for JOIN, subquery, and multiple queries per stream details.
 See [Examples & Demos](https://docs.powersync.com/sync/streams/examples.md) for complete working app patterns.
 


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/517

### What changed in docs

Query examples throughout the docs were updated to put `*` before aliased columns (e.g. `SELECT *, _id as id FROM collection`). A new warning was added explaining that the last column with a given name wins, so aliases after `*` are silently overwritten if the source table has a matching column name.

### Skill updates in this PR

- `skills/powersync/references/sync-config.md`: Added a new "ID Column Aliasing" pattern under Common Patterns with the correct `SELECT *, _id as id FROM ...` form and an explanation of the column precedence rule.

### Notes for reviewer

- No stale `SELECT _id as id, *` patterns were found in any other skill file. The skills had no prior examples using this pattern, so no corrections were needed elsewhere.
- The Sync Rules (legacy) section was not updated. Sync Rules use a different query evaluation model and the docs PR did not touch Sync Rules examples.
- `AGENTS.md` and `SKILL.md` were not changed. This is a query syntax rule, not an onboarding or routing change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvR6rdZhdDM3pQmiq6fR4y)_