### PR TITLE
Sync from docs: update Docker image tag and release channel guidance (powersync-docs #519)

### DIFF
--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -42,6 +42,15 @@ Information on how to configure a PowerSync Service instance in a self-hosted en
 ### Docker Image
 The PowerSync Service Docker image is available on [Docker hub](https://hub.docker.com/r/journeyapps/powersync-service).
 
+Releases are published to two channels: Stable and Next. For self-hosted, select the channel by choosing the image tag. For PowerSync Cloud, configure the channel per instance in the Dashboard under Settings.
+
+| Channel | Example tags                         | Use for                   |
+| ------- | ------------------------------------ | ------------------------- |
+| Stable  | `1.23.0`, `1.23`, `1`                | Production                |
+| Next    | `1.23.0-next`, `1.23-next`, `1-next` | Testing upcoming releases |
+
+If generating a production Docker Compose or run command, use a pinned Stable tag (e.g. `1.23.0`) rather than `latest`. The `latest` tag tracks the current Stable release but can advance across major versions; treat it as development-only.
+
 Quick Start:
 ```
 docker run \
@@ -67,7 +76,7 @@ There are four configuration methods available:
 
 ```yaml
 powersync:
-  image: journeyapps/powersync-service:latest
+  image: journeyapps/powersync-service:latest  # For production, use a pinned tag (e.g. 1.23.0)
   ports:
     - "8080:8080"
   environment:


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/519

### What changed in docs

The Feature Status page restructured the release channel model: PowerSync Service now publishes to two explicit channels (Stable and Next), with a tag table for self-hosted Docker images. The docs now state that `latest` is for development only and production should use a pinned version tag such as `1.23.0`.

### Skill updates in this PR

- `skills/powersync/references/powersync-service.md`: Added a Stable/Next channel table and a conditional rule under the Docker Image section. If generating a production Docker Compose or run command, use a pinned Stable tag (e.g. `1.23.0`) rather than `latest`. The `latest` tag tracks the current Stable release but can advance across major versions. Also added an inline comment to the Docker Compose image line flagging the same. PowerSync Cloud channel selection is noted as a Dashboard Settings action per instance.

### Notes for reviewer

- The quick-start `docker run` example retains `latest` since it is a development-oriented example. The new rule above it covers the production case.
- The `latest` tag in the Docker Compose example now carries an inline comment rather than a rewrite, keeping the example minimal while surfacing the production guidance.
- No changes were made to Kubernetes, Terraform, or onboarding files. The channel concept does not affect Kubernetes deployments, which use the Helm chart with its own version pinning.
- The stale `[Metrics]` link in the Observability section (should be `[Usage Reporting]`) was left untouched. That is tracked in open agent-skills PR #45.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzjqhsLeBLR4tRtEf8Lbui)_