### PR TITLE
Sync from docs: fix encryption key escape in Node.js example (powersync-docs #529)

### DIFF
--- a/skills/powersync/references/sdks/powersync-js-node.md
+++ b/skills/powersync/references/sdks/powersync-js-node.md
@@ -192,3 +192,16 @@ npx @electron/rebuild -f -w better-sqlite3
 ```
 
 Run this after any Electron version upgrade.
+
+### Encryption Key Escaping
+
+If the encryption key passed to `pragma key` may contain single quotes, use `replaceAll` to escape them, not `replace`. The `replace` method only replaces the first occurrence; a key with multiple single quotes will be incorrectly escaped, causing a decryption failure or SQL syntax error.
+
+```ts
+initializeConnection: async (db) => {
+  if (encryptionKey.length) {
+    const escapedKey = encryptionKey.replaceAll("'", "''");
+    await db.execute(`pragma key = '${escapedKey}'`);
+  }
+}
+```


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/529

### What changed in docs

The Node.js reference fixed a bug in the encryption key escaping example: `replace("'", "''")` was changed to `replaceAll("'", "''")`. The old code only escaped the first single quote in the key; the new code escapes all of them.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-js-node.md`: Added an "Encryption Key Escaping" entry under Common Pitfalls documenting the correct use of `replaceAll` when setting `pragma key`.

### Notes for reviewer

The skill file previously had no encryption example. Adding it as a pitfall is the right call: if an agent generates encryption setup code for Node.js and uses `replace` instead of `replaceAll`, the result silently fails for any key containing more than one single quote. The new entry follows the conditional voice convention already used in the file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXWpx4CN9wBEKpC2v2G68V)_