### PR TITLE
Sync from docs: note Swift Data community ORM for Swift (powersync-docs #534)

### DIFF
--- a/skills/powersync/references/sdks/powersync-swift.md
+++ b/skills/powersync/references/sdks/powersync-swift.md
@@ -1,8 +1,8 @@
 ---
 name: powersync-swift
-description: PowerSync Swift SDK — schema, queries, sync lifecycle, backend connectors, and GRDB ORM support
+description: PowerSync Swift SDK: schema, queries, sync lifecycle, backend connectors, GRDB ORM support, and Swift Data community integration
 metadata:
-  tags: swift, ios, macos, grdb, orm, sqlite, offline-first
+  tags: swift, ios, macos, grdb, orm, sqlite, offline-first, swift-data
 ---
 
 # PowerSync Swift SDK
@@ -19,7 +19,7 @@ Best practices and guidance for building apps with the PowerSync Swift SDK.
 ## Installation
 
 | Method | Instructions |
-|--------|-------------|
+|--------|--------------|
 | `Package.swift` | [Installation - Package.swift](https://docs.powersync.com/client-sdks/reference/swift.md#package-swift) |
 | Xcode | [Installation - Xcode](https://docs.powersync.com/client-sdks/reference/swift.md#xcode) |
 
@@ -185,7 +185,7 @@ try await db.writeTransaction { tx in
 
 ## ORM — GRDB
 
-PowerSync Swift supports GRDB as an ORM. Requires PowerSync Swift v1.9.0+.
+PowerSync Swift officially supports GRDB as an ORM. Requires PowerSync Swift v1.9.0+.
 
 Setup requires a `DatabasePool` with PowerSync config — see [GRDB Setup](https://docs.powersync.com/client-sdks/orms/swift/grdb.md#setup).
 
@@ -210,3 +210,7 @@ try await pool.write { db in
 ```
 
 See [GRDB Architecture](https://docs.powersync.com/client-sdks/orms/swift/grdb.md#architecture) for how the PowerSync + GRDB integration works.
+
+## ORM: Swift Data (Community)
+
+If the project uses Swift Data models, a community-contributed integration is available: [powersync-community/swift-data](https://github.com/powersync-community/swift-data). This integration is community-owned and not officially supported by PowerSync. For setup and usage, see the repository README.


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/534

### What changed in docs

The Swift SDK reference now clarifies that GRDB is officially supported, and adds a brief mention of a community-contributed Swift Data integration that is not officially supported by PowerSync.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-swift.md`: Updated frontmatter description to include Swift Data; added "officially" to the GRDB support line; added a new "ORM: Swift Data (Community)" section pointing to the community repository.

### Notes for reviewer

The Swift Data section intentionally links to the repository README for setup details rather than duplicating instructions, matching the approach taken in the docs PR. No new reference file was created for Swift Data since there is no official integration and no detailed API surface to document.

Assigning bean1352 as assignee failed (422: cannot request review from PR author). michaelbarnes was successfully added as reviewer.