### PR TITLE
Sync from docs: add source DB minimum versions and Expo setup requirements (powersync-docs #458)

### DIFF
--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -297,6 +297,18 @@ See [Source Database Setup](https://docs.powersync.com/configuration/source-db/s
 
 Both PowerSync Cloud and Self-hosted require the same base source database setup.
 
+### Minimum Supported Versions
+
+If the operator's source database version is below the minimum, advise them to upgrade before proceeding.
+
+| Database | Minimum Version |
+|----------|-----------------|
+| PostgreSQL | 11+ |
+| MongoDB | 6.0+ |
+| MySQL | 5.7+ |
+| SQL Server | 2019+ (15.0+), or Azure SQL Database |
+| Convex | — (alpha) |
+
 ### PostgreSQL Quick Start
 
 ```sql

--- a/skills/powersync/references/sdks/powersync-js-react-native.md
+++ b/skills/powersync/references/sdks/powersync-js-react-native.md
@@ -21,6 +21,8 @@ The React hooks API (`useQuery`, `useStatus`, `usePowerSync`, `useSuspenseQuery`
 
 ## 1. Install
 
+Requires React Native 0.72 or later.
+
 ### Standard React Native (Recommended)
 
 ```bash
@@ -78,6 +80,8 @@ export const db = new PowerSyncDatabase({
 By default, `@powersync/react-native` uses OP-SQLite if installed, falling back to React Native Quick SQLite. No additional configuration is needed to select the adapter — the SDK detects which peer is present.
 
 ## Expo
+
+Requires Expo 49 or later. If the Expo version is 49, configure `expo-build-properties` to set `minSdkVersion: 24` and add `'mjs'` to Metro `sourceExts`. If the version is 50 or 51, set only `minSdkVersion: 24` in `expo-build-properties`. Expo 52 and later configure both settings automatically.
 
 ### Managed Workflow
 


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/458

### What changed in docs

The Supported Platforms page was expanded to include minimum version requirements for all source databases (Postgres 11+, MongoDB 6.0+, MySQL 5.7+, SQL Server 2019+, Convex alpha) and per-SDK minimum platform versions, including React Native 0.72+ and Expo 49+ with specific per-version configuration requirements.

### Skill updates in this PR

- `skills/powersync/references/powersync-service.md`: Added a "Minimum Supported Versions" table to the Source Database Setup section. If the operator's source database is below the minimum, the agent has the info to flag it before proceeding.
- `skills/powersync/references/sdks/powersync-js-react-native.md`: Added React Native 0.72 minimum version note to the install section. Added Expo 49+ minimum with per-version configuration requirements (minSdkVersion, Metro sourceExts) to the Expo section.

### Notes for reviewer

Minimum platform OS/SDK versions for the Dart, Kotlin, Swift, and .NET SDK files are not added in this PR. The Dart file already links to the supported-platforms page for compatibility details. The other SDK files do not document platform minimums, and adding them would go beyond what the docs change implies for each file. A follow-up PR could add minimum platform version notes to each SDK reference file if that is considered worthwhile.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae4UEsdvMpnNXScFYxa758)_