### PR TITLE
Sync from docs: add Azure DocumentDB source database support (powersync-docs #516)

### DIFF
--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -2,7 +2,7 @@
 name: powersync-service
 description: PowerSync Service configuration — self-hosting, Docker, Kubernetes, Helm, source database setup, bucket storage, authentication, and PowerSync Cloud
 metadata:
-  tags: service, self-hosted, docker, postgresql, mongodb, mysql, mssql, convex, authentication, jwt, replication, configuration, private-endpoints, privatelink, vpc, aws, kubernetes, helm, eks
+  tags: service, self-hosted, docker, postgresql, mongodb, documentdb, cosmosdb, mysql, mssql, convex, authentication, jwt, replication, configuration, private-endpoints, privatelink, vpc, aws, kubernetes, helm, eks
 ---
 
 # PowerSync Service
@@ -343,6 +343,35 @@ db.createUser({
 
 // Change streams are used automatically
 ```
+
+### Azure DocumentDB (Cosmos DB for MongoDB vCore)
+
+> **Experimental.** Azure DocumentDB support is experimental; APIs and behavior may change, and it is not yet covered by SLAs. See [Feature Status](https://docs.powersync.com/resources/feature-status) for production-readiness details.
+
+If the operator is connecting to Azure DocumentDB (formerly Azure Cosmos DB for MongoDB vCore), use `type: mongodb` and point it at the DocumentDB connection string. PowerSync detects DocumentDB automatically. Do not use a separate connector type.
+
+Setup, permissions, and connection steps are the same as MongoDB above. The one difference: `post_images` must be `off` (the default). The `auto_configure` and `read_only` Post Images modes fail on DocumentDB.
+
+#### Supported Variants
+
+Only the vCore engine is supported. If a source does not report as DocumentDB, PowerSync treats it as standard MongoDB.
+
+| Variant | Supported |
+| --- | --- |
+| Azure DocumentDB / Azure Cosmos DB for MongoDB vCore | Yes |
+| Azure Cosmos DB for MongoDB (RU-based) | No |
+| Azure Cosmos DB for NoSQL | No |
+| Self-hosted open-source DocumentDB engine (`documentdb-local`) | No |
+
+If the operator is on the RU-based model, direct them to the [Microsoft migration guide](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/how-to-migrate-documentdb) before connecting.
+
+#### Limitations to Flag Before Connecting
+
+- **Post-images are not supported.** Use `post_images: off` (the default). Updates and deletes still replicate correctly because DocumentDB always includes the full document on change events. Only the `auto_configure` and `read_only` consistency modes are unavailable.
+- **Collection drop and rename are not replicated.** If a replicated collection is dropped or renamed, already-synced rows remain under the old name. Recovery requires redeploying Sync Streams to trigger a resync.
+- **Documents at or above 15 MiB are dropped** with a logged error. This limit is more reachable on DocumentDB because every change event carries the full document. Large documents also replicate more slowly.
+- **Large initial snapshots require storage v3 or later.** On storage v1 or v2, a large or active source can exhaust its change-feed history window before the snapshot completes, causing replication to loop. Storage v3 avoids this by streaming during the snapshot.
+- **Do not drop `_powersync_checkpoints`** or delete its documents. Doing so disrupts replication.
 
 ### MySQL Quick Start
 


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/516

### What changed in docs

PR #516 documents experimental Azure DocumentDB (Cosmos DB for MongoDB vCore) support. It covers how DocumentDB connects via the existing MongoDB connector, which variants are supported (only vCore), and four limitations that differ from standard MongoDB.

### Skill updates in this PR

- `skills/powersync/references/powersync-service.md`: Added a new "Azure DocumentDB (Cosmos DB for MongoDB vCore)" section under Source Database Setup. The section covers connector setup (`type: mongodb`, `post_images: off`), a supported variants table (only vCore works; RU-based, NoSQL, and self-hosted engine do not), and the four limitations an agent needs before helping a user connect. Also added `documentdb` and `cosmosdb` to the skill metadata tags so the file loads when an operator mentions either term.

### Notes for reviewer

The AGENTS.md ask list ("which database (Supabase, Postgres, MongoDB, MySQL, MSSQL, or Convex)") was not updated. DocumentDB is experimental and uses the MongoDB connector, so it fits under the MongoDB path without a separate list entry. A reviewer may want to add a parenthetical (e.g., "MongoDB or Azure DocumentDB") to help the agent recognize DocumentDB as a valid answer, but that goes beyond what the docs change directly implies.

The feature-status page change (adding DocumentDB to the experimental features table) has no direct skill counterpart beyond this section.

---
_Generated by [Claude Code](https://claude.ai/code/session_012VZhsZyNez4GUiiZbKvD46)_