### PR TITLE
Sync from docs: add InMemoryVFS web option (powersync-docs #538)

### DIFF
--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -310,6 +310,7 @@ Multi-tab behavior: By default the web SDK uses a shared sync worker so all tabs
 |---------------------------|---------------------|---------------------------------------------------------------------------------------------------------|
 | IDBBatchAtomicVFS         | Default             | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#1-idbbatchatomicvfs-default)     |
 | OPFSCoopSyncVFS           | Recommended         | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#2-opfs-based-alternatives)       |
+| InMemoryVFS               | No persistence; fast queries; for development or online-only apps with small datasets | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#3-in-memory-vfs) |
 
 ```ts
 // Recommended — more reliable across browsers including Safari
@@ -325,6 +326,25 @@ const db = new PowerSyncDatabase({
 ```
 
 Safari: Requires `OPFSCoopSyncVFS` for stable multi-tab, or set `useWebWorker: false`. See [Web SDK Reference](https://docs.powersync.com/client-sdks/reference/javascript-web.md) for full configuration options.
+
+If the user needs a non-persistent database, use `WASQLiteVFS.InMemoryVFS` (requires `@powersync/web` 1.39.0+). No data is persisted: local writes are lost if the tab closes before uploading. Use for development workflows where a fresh database on each load is desirable, or for online-only apps with frequent queries and small datasets. Do not use when offline support is required.
+
+On Chrome and Firefox Desktop, InMemoryVFS uses a shared worker by default, so all tabs share the same in-memory database and sync worker. To isolate tabs, pass `enableMultiTabs: false` and a unique `dbFilename` per tab:
+
+```js
+export const db = new PowerSyncDatabase({
+  schema: AppSchema,
+  database: new WASQLiteOpenFactory({
+    dbFilename: `memory-${crypto.randomUUID()}.db`,
+    vfs: WASQLiteVFS.InMemoryVFS
+  }),
+  flags: {
+    enableMultiTabs: false
+  }
+});
+```
+
+When InMemoryVFS is used in production, watch `SELECT * FROM ps_crud LIMIT 1` to detect outstanding local mutations and surface that state to the user. Consider a `beforeunload` listener that calls `preventDefault()` to prompt before closing a tab with unsynced writes.
 
 ## Query Patterns
 


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/538

### What changed in docs

Added documentation for `WASQLiteVFS.InMemoryVFS`, a new VFS option in `@powersync/web` 1.39.0+. The option provides non-persistent, fast in-memory storage suited for development and online-only apps.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-js.md`: Added `InMemoryVFS` to the VFS options table and a guidance block covering when to use it, multi-tab behavior on Chrome and Firefox Desktop, the tab-isolation pattern, and the `ps_crud` monitoring caveat for production use.

### Notes for reviewer

The skill update captures the decision-relevant facts an agent needs: when to recommend InMemoryVFS, when not to (offline support required), the multi-tab shared-worker default, and the production caveat around unsynced writes. The tab-isolation code example is taken directly from the docs. No new skill file was needed; the existing VFS section in `powersync-js.md` was the right location.

---
_Generated by [Claude Code](https://claude.ai/code/session_016MvoGkqwFQtLCy86AxwnFR)_