### PR TITLE
Update JS SDK skills for v2 API changes (docs PR #524)

### DIFF
--- a/skills/powersync/references/sdks/powersync-js-react-native.md
+++ b/skills/powersync/references/sdks/powersync-js-react-native.md
@@ -23,20 +23,11 @@ The React hooks API (`useQuery`, `useStatus`, `usePowerSync`, `useSuspenseQuery`
 
 Requires React Native 0.72 or later.
 
-### Standard React Native (Recommended)
+### Standard React Native
 
 ```bash
 npm install @powersync/react-native@latest
-```
-
-Then install a native SQLite adapter (required peer dependency):
-
-```bash
-# OP-SQLite — recommended: built-in encryption, React Native New Architecture support
-npm install @powersync/op-sqlite@latest
-
-# OR: React Native Quick SQLite — original adapter
-npm install @journeyapps/react-native-quick-sqlite@latest
+npm install @op-engineering/op-sqlite  # Required peer dependency
 ```
 
 After installing native dependencies, rebuild your native app:
@@ -77,7 +68,7 @@ export const db = new PowerSyncDatabase({
 });
 ```
 
-By default, `@powersync/react-native` uses OP-SQLite if installed, falling back to React Native Quick SQLite. No additional configuration is needed to select the adapter — the SDK detects which peer is present.
+The `database: { dbFilename: '...' }` config uses OP-SQLite via the `@op-engineering/op-sqlite` peer dependency. No additional configuration is needed.
 
 ## Expo
 
@@ -88,7 +79,7 @@ Requires Expo 49 or later. If the Expo version is 49, configure `expo-build-prop
 PowerSync works with Expo managed workflow. Native adapters (recommended) require a development build because they use native modules. If you need to run in Expo Go, use the JavaScript-only adapter instead. See the Expo Go section below.
 
 ```bash
-npx expo install @powersync/react-native @powersync/op-sqlite
+npx expo install @powersync/react-native @op-engineering/op-sqlite
 npx expo prebuild
 npx expo run:ios   # or run:android
 ```
@@ -125,7 +116,7 @@ import { PowerSyncDatabase, Schema } from '@powersync/react-native';
 
 export const powerSync = new PowerSyncDatabase({
   schema: new Schema({}), // define your schema here
-  database: new SQLJSOpenFactory({
+  factory: new SQLJSOpenFactory({
     dbFilename: 'app.db',
   }),
 });
@@ -137,27 +128,25 @@ Use `Constants.executionEnvironment` to select the adapter at runtime, allowing 
 
 ```tsx
 import { SQLJSOpenFactory } from '@powersync/adapter-sql-js';
-import { PowerSyncDatabase } from '@powersync/react-native';
+import { DatabaseSource, PowerSyncDatabase } from '@powersync/react-native';
 import Constants from 'expo-constants';
 
 const isExpoGo = Constants.executionEnvironment === 'storeClient';
 
-export const powerSync = new PowerSyncDatabase({
-  schema: AppSchema,
-  database: isExpoGo
-    ? new SQLJSOpenFactory({ dbFilename: 'app.db' })
-    : { dbFilename: 'sqlite.db' }, // uses native adapter
-});
+const source: DatabaseSource = isExpoGo
+  ? { factory: new SQLJSOpenFactory({ dbFilename: 'app.db' }) }
+  : { database: { dbFilename: 'sqlite.db' } };
+
+export const powerSync = new PowerSyncDatabase({ schema: AppSchema, ...source });
 ```
 
 ### Moving Beyond Expo Go
 
 When moving to development builds or production, switch to a native adapter:
 
-- OP-SQLite (`@powersync/op-sqlite`) — recommended; encryption support, New Architecture compatible
-- React Native Quick SQLite (`@journeyapps/react-native-quick-sqlite`) — original adapter
+- OP-SQLite (`@op-engineering/op-sqlite`) — recommended; encryption support, New Architecture compatible
 
-These require native compilation and cannot run inside Expo Go's prebuilt container.
+This requires native compilation and cannot run inside Expo Go's prebuilt container.
 
 ## Common Pitfalls
 

--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -75,7 +75,7 @@ npm install @journeyapps/wa-sqlite@latest # Needed (peer-dependency)
 
 # React Native
 npm install @powersync/react-native@latest
-npm install @powersync/powersync-op-sqlite@latest  # Needed (peer-dependency)
+npm install @op-engineering/op-sqlite  # Needed (peer-dependency)
 
 # Node.js
 npm install @powersync/node@latest
@@ -293,11 +293,9 @@ const db = new PowerSyncDatabase({
   schema,
   database: {
     dbFilename: 'app.db',
-    debugMode: true        // Logs all SQL to Chrome DevTools Performance timeline
-  },
-  flags: {
-    useWebWorker: true,    // Default true — runs DB in a web worker
-    enableMultiTabs: true  // Default true — shares sync worker across tabs
+    debugMode: true,           // Logs all SQL to Chrome DevTools Performance timeline
+    useWebWorker: true,        // Default true — runs DB in a web worker
+    enableMultiTabs: true      // Default true — shares sync worker across tabs
   }
 });
 ```
@@ -313,14 +311,14 @@ Multi-tab behavior: By default the web SDK uses a shared sync worker so all tabs
 
 ```ts
 // Recommended — more reliable across browsers including Safari
-import { WASQLiteOpenFactory, WASQLiteVFS } from '@powersync/web'
+import { WASQLiteVFS } from '@powersync/web'
 
 const db = new PowerSyncDatabase({
   schema,
-  database: new WASQLiteOpenFactory({
+  database: {
     dbFilename: 'app.db',
     vfs: WASQLiteVFS.OPFSCoopSyncVFS, // default: IDBBatchAtomicVFS
-  }),
+  },
 })
 ```
 
@@ -512,20 +510,17 @@ const status = useStatus();
 //   lastSyncedAt: Date | null,
 //   hasSynced: boolean,          // true after first full sync, persists across restarts
 //   isSyncing: boolean,
+//   uploading: boolean,
+//   downloading: boolean,
+//   uploadError: Error | undefined,    // set on upload failure, cleared on next success
+//   downloadError: Error | undefined,  // set on download/connect failure, cleared on next success
 //   downloadProgress: DownloadProgress | null,
-//   dataFlowStatus: {
-//     uploading: boolean,
-//     downloading: boolean,
-//     uploadError: Error | undefined,    // set on upload failure, cleared on next success
-//     downloadError: Error | undefined,  // set on download/connect failure, cleared on next success
-//     downloadProgress: ...
-//   }
 // }
 ```
 
 #### uploadError and downloadError
 
-`status.dataFlowStatus.uploadError` and `status.dataFlowStatus.downloadError` are the primary way to surface sync failures to users or logging systems.
+`status.uploadError` and `status.downloadError` are the primary way to surface sync failures to users or logging systems.
 
 - `uploadError` — set when an exception occurs during the CRUD upload loop. Cleared automatically on the next successful upload.
 - `downloadError` — set when an exception occurs during the streaming sync (including connection failures). Cleared on the next successful data download or checkpoint completion.
@@ -533,11 +528,11 @@ const status = useStatus();
 ```tsx
 const status = useStatus();
 
-if (status.dataFlowStatus?.uploadError) {
-  return <Banner>Failed to save changes: {status.dataFlowStatus.uploadError.message}</Banner>;
+if (status.uploadError) {
+  return <Banner>Failed to save changes: {status.uploadError.message}</Banner>;
 }
-if (status.dataFlowStatus?.downloadError) {
-  return <Banner>Sync error: {status.dataFlowStatus.downloadError.message}</Banner>;
+if (status.downloadError) {
+  return <Banner>Sync error: {status.downloadError.message}</Banner>;
 }
 ```
 
@@ -546,16 +541,16 @@ Register a status listener imperatively (useful for logging, not just UI):
 ```ts
 db.registerListener({
   statusChanged: (status) => {
-    if (status.dataFlowStatus?.downloadError) {
+    if (status.downloadError) {
       logger.error('PowerSync download failed', {
-        error: status.dataFlowStatus.downloadError,
+        error: status.downloadError,
         lastSyncedAt: status.lastSyncedAt,
         connected: status.connected,
       });
     }
-    if (status.dataFlowStatus?.uploadError) {
+    if (status.uploadError) {
       logger.error('PowerSync upload failed', {
-        error: status.dataFlowStatus.uploadError,
+        error: status.uploadError,
         lastSyncedAt: status.lastSyncedAt,
         connected: status.connected,
       });
@@ -726,11 +721,9 @@ Connect this to a running PowerSync instance to inspect tables, rows, sync bucke
 ### Enable SDK Logging (Development)
 
 ```ts
-import { createBaseLogger, LogLevel } from '@powersync/react'; // or @powersync/common
+import { createConsoleLogger, LogLevels } from '@powersync/react'; // or @powersync/common
 
-const logger = createBaseLogger();
-logger.useDefaults(); // output to console
-logger.setLevel(LogLevel.DEBUG); // DEBUG | INFO | WARN | ERROR | TRACE | OFF
+const logger = createConsoleLogger({ minLevel: LogLevels.debug }); // trace | debug | info | warn | error
 ```
 
 ### Production Logging
@@ -742,11 +735,9 @@ The key pattern is: use `WARN` level in production (captures errors and warnings
 Example using Sentry (substitute your own provider):
 
 ```ts
-import { createBaseLogger, LogLevel } from '@powersync/react-native';
+import { createConsoleLogger, LogLevels } from '@powersync/react-native';
 
-const logger = createBaseLogger();
-logger.useDefaults();
-logger.setLevel(LogLevel.WARN); // WARN and above in production
+const logger = createConsoleLogger({ minLevel: LogLevels.warn }); // warn and above in production
 
 logger.setHandler((messages, context) => {
   if (!context?.level) return;
@@ -776,17 +767,17 @@ Also register a status listener to capture `uploadError` and `downloadError` —
 ```ts
 db.registerListener({
   statusChanged: (status) => {
-    if (status.dataFlowStatus?.downloadError) {
+    if (status.downloadError) {
       logger.error('PowerSync download error', {
-        error: status.dataFlowStatus.downloadError,
+        error: status.downloadError,
         lastSyncedAt: status.lastSyncedAt,
         connected: status.connected,
         sdkVersion: db.sdkVersion,
       });
     }
-    if (status.dataFlowStatus?.uploadError) {
+    if (status.uploadError) {
       logger.error('PowerSync upload error', {
-        error: status.dataFlowStatus.uploadError,
+        error: status.uploadError,
         lastSyncedAt: status.lastSyncedAt,
         connected: status.connected,
         sdkVersion: db.sdkVersion,


### PR DESCRIPTION
Triggered by [powersync-docs PR #524](https://github.com/powersync-ja/powersync-docs/pull/524) — "Update JavaScript docs for v2 release", merged from `js-v2` into `main`.

### What changed in docs

PR #524 documented breaking API changes in `@powersync/react-native`, `@powersync/web`, and `@powersync/node` for the v2 release:

- **Peer dependency**: `@powersync/op-sqlite` wrapper removed; `@op-engineering/op-sqlite` is now installed directly. `@journeyapps/react-native-quick-sqlite` support dropped.
- **Constructor flags**: `flags.useWebWorker`, `flags.enableMultiTabs` moved into the `database` config object. The `flags` top-level key is gone.
- **VFS config**: `new WASQLiteOpenFactory({ vfs: ... })` replaced by a plain config object `{ vfs: ... }` passed to `database`.
- **Logger API**: `createBaseLogger()` + `useDefaults()` + `setLevel(LogLevel.X)` replaced by `createConsoleLogger({ minLevel: LogLevels.x })`.
- **SyncStatus**: `status.dataFlowStatus.uploadError` / `status.dataFlowStatus.downloadError` flattened to `status.uploadError` / `status.downloadError`.
- **Expo Go factory key**: Factory instances (`SQLJSOpenFactory`) now go under `factory:`, not `database:`.
- **DatabaseSource type**: New type for cleanly switching between Expo Go and native adapters using spread.

### Skill updates in this PR

**`skills/powersync/references/sdks/powersync-js.md`**

- Install section: `@powersync/powersync-op-sqlite@latest` replaced with `@op-engineering/op-sqlite`
- Web-specific options: `flags: { useWebWorker, enableMultiTabs }` moved into `database:` config block
- VFS example: removed `WASQLiteOpenFactory` import and wrapper; plain object used for `database`
- Logger examples: `createBaseLogger`/`LogLevel` replaced with `createConsoleLogger`/`LogLevels` in both development and production logging sections
- SyncStatus type comment: `dataFlowStatus` nesting removed; `uploading`, `downloading`, `uploadError`, `downloadError` shown as top-level fields
- All `status.dataFlowStatus?.uploadError` and `status.dataFlowStatus?.downloadError` references updated to `status.uploadError` and `status.downloadError`

**`skills/powersync/references/sdks/powersync-js-react-native.md`**

- Install section: simplified to `@op-engineering/op-sqlite` as the single required peer dep; `@journeyapps/react-native-quick-sqlite` option removed
- DB init note: updated to reflect direct `@op-engineering/op-sqlite` usage
- Expo managed workflow install command: `@powersync/op-sqlite` replaced with `@op-engineering/op-sqlite`
- Expo Go usage example: `database: new SQLJSOpenFactory(...)` changed to `factory: new SQLJSOpenFactory(...)`
- Switching adapters example: updated to use `DatabaseSource` type with spread pattern
- Moving Beyond Expo Go: removed Quick SQLite bullet; updated OP-SQLite package name to `@op-engineering/op-sqlite`

### Notes for reviewer

All changes follow the docs PR exactly. No behaviour was inferred — every edit maps to an explicit API change documented in PR #524. The `DatabaseSource` spread pattern is taken directly from the updated docs example.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZEtAz8WtASLSognHzCsxk)_