### PR TITLE
Sync from docs: add @powersync/common as canonical API reference (powersync-docs #542)

### DIFF
--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -37,6 +37,7 @@ Core patterns and guidance shared across all PowerSync JavaScript/TypeScript tar
 | [Capacitor SDK API Reference](https://powersync-ja.github.io/powersync-js/capacitor-sdk) | Full API reference for `@powersync/capacitor`, consult only when the inline examples don't cover your case. |
 | [Node.js Reference](https://docs.powersync.com/client-sdks/reference/node.md) | Full SDK documentation for Node.js, consult for details beyond the inline examples. |
 | [Node.js SDK API Reference](https://powersync-ja.github.io/powersync-js/node-sdk) | Full API reference for `@powersync/node`, consult only when the inline examples don't cover your case. |
+| [Common Package API Reference](https://powersync-ja.github.io/powersync-js/common) | Canonical API reference for `@powersync/common`. Use this for `CommonPowerSyncDatabase` (the public database interface, re-exported from all SDK packages) and `SyncStatus` (interface). In SDK v2, `PowerSyncDatabase` methods and `SyncStatus` properties are documented here rather than on SDK-specific class pages. |
 | [Supported Platforms - JS SDK](https://docs.powersync.com/resources/supported-platform.md#javascript-web-sdk) | Supported platforms and features, consult for compatibility details. |
 
 Framework-specific files (load alongside this file):


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/542

### What changed in docs

In JS SDK v2, `PowerSyncDatabase` and `SyncStatus` are exported as interfaces from `@powersync/common` (`CommonPowerSyncDatabase` and `SyncStatus`) rather than as concrete classes in each SDK package. The docs PR updated all API documentation links to point to these canonical `@powersync/common` interface pages.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-js.md`: Added a row for the `@powersync/common` package API reference to the resource table, noting it is the canonical source for `CommonPowerSyncDatabase` (the public database interface) and `SyncStatus` in SDK v2.

### Notes for reviewer

The docs PR also renamed `WASQLiteDBAdapter` to `WASQLiteOpenFactory` in the documentation, but `powersync-js.md` already uses `WASQLiteOpenFactory`, so no change was needed there.

An open PR (#60) for docs PR #524 already updates `powersync-js.md` with broader v2 API changes (logger API, `dataFlowStatus` flattening, VFS config). The change in this PR is additive and does not conflict with those edits.

No other skill files contain the affected URL patterns or class names. The `production-readiness-guide.mdx` change (consolidating three `SyncStatus` links into one) does not have a skill counterpart.

---
_Generated by [Claude Code](https://claude.ai/code/session_019KRkwq5fH1jFydqYKcAxi7)_