### PR TITLE
Sync from docs: Kotlin v1.14.1 web target support and Room 3.0 requirement (powersync-docs #548)

### DIFF
--- a/skills/powersync/references/sdks/powersync-kotlin.md
+++ b/skills/powersync/references/sdks/powersync-kotlin.md
@@ -21,7 +21,7 @@ metadata:
 
 Best practices for building apps with the PowerSync Kotlin SDK.
 
-Supported targets: Android, JVM, iOS, macOS, watchOS, tvOS.
+Supported targets: Android, JVM, iOS, macOS, watchOS, tvOS. Web (JS and WebAssembly) targets have experimental support from v1.14.1. Web is not production-ready; use from a single tab only (multi-tab sync coordination is not functional in this version).
 
 ## Installation
 
@@ -46,6 +46,8 @@ commonMain.dependencies {
 ```
 
 From v1.12.0+ the PowerSync SQLite core extension is statically linked into `com.powersync:core` for all Apple targets (iOS, macOS, tvOS, watchOS), matching Android and JVM. **No CocoaPod or Swift Package dependency on `powersync-sqlite-core` is needed.** Upgrading from an older version? Remove any `pod("powersync-sqlite-core")` entry and any `powersync-sqlite-core-swift` SPM dependency.
+
+For web targets (JS and WebAssembly), use `WebConnectionFactory` to open a PowerSync database. Web support is experimental (added in v1.14.1) and not production-ready. Use from a single tab only; multi-tab sync coordination is not functional.
 
 ## Quick Setup
 
@@ -439,7 +441,7 @@ Full example: [`demos/supabase-todolist/androidBackgroundSync`](https://github.c
 
 ## ORM Integrations
 
-- **Room** (beta) — typed queries with compile-time validation: `com.powersync:powersync-room:$powersyncVersion` · [Docs](https://docs.powersync.com/client-sdks/orms/kotlin/room.md)
+- **Room** (beta) — typed queries with compile-time validation: `com.powersync:integration-room:$powersyncVersion` · [Docs](https://docs.powersync.com/client-sdks/orms/kotlin/room.md). If using v1.14.1 or later, upgrade Room to 3.0 before updating the integration.
 - **SQLDelight** (beta) — `PowerSyncDriver` implements `SqlDriver`: `com.powersync:powersync-sqldelight:$powersyncVersion` · [Docs](https://docs.powersync.com/client-sdks/orms/kotlin/sqldelight.md)
 
 ## Additional Resources


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/548

### What changed in docs

Kotlin SDK v1.14.1 adds experimental web (JS and WebAssembly) support via `WebConnectionFactory`, with a hard constraint that multi-tab sync coordination is not functional. The `com.powersync:integration-room` package now requires Room 3.0 when upgrading to v1.14.1 or later.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-kotlin.md`: Updated the supported-targets line to include experimental web support with the single-tab constraint. Added a note in the Installation section about `WebConnectionFactory` for web targets. Updated the Room ORM entry with the Room 3.0 upgrade requirement for v1.14.1+. Also corrected the Room package name from `com.powersync:powersync-room` to `com.powersync:integration-room` to match the docs.

### Notes for reviewer

The previous skill listed the Room integration artifact as `com.powersync:powersync-room`. The docs consistently use `com.powersync:integration-room`. This PR updates the skill to match. If `powersync-room` is a valid separate artifact (not a renamed package), revert that specific name change.

Web support is experimental with a clear production warning in the docs. The skill reflects the single-tab constraint inline, without adding a new section. No other files were touched.

Reviewer assignment: `michaelbarnes` was added as reviewer. Assigning `bean1352` returned a 422 (cannot request review from PR author).