### PR TITLE
Sync from docs: remove @journeyapps/wa-sqlite peer dep from web install (powersync-docs #550)

### DIFF
--- a/skills/powersync/references/sdks/powersync-js-react.md
+++ b/skills/powersync/references/sdks/powersync-js-react.md
@@ -134,7 +134,7 @@ PowerSync is tailored for client-side applications. Next.js evaluates code in a 
 ### Install
 
 ```bash
-npm install @powersync/web@latest @journeyapps/wa-sqlite@latest @powersync/react@latest
+npm install @powersync/web@latest @powersync/react@latest
 ```
 
 ### Copy Worker Assets (Turbopack)

--- a/skills/powersync/references/sdks/powersync-js-tanstack.md
+++ b/skills/powersync/references/sdks/powersync-js-tanstack.md
@@ -109,7 +109,7 @@ Use plain PowerSync (`.watch()` / `usePowerSyncQuery`) when:
 
 ```bash
 # Web
-npm install @tanstack/powersync-db-collection@latest @powersync/web@latest @journeyapps/wa-sqlite@latest
+npm install @tanstack/powersync-db-collection@latest @powersync/web@latest
 
 # React Native
 npm install @tanstack/powersync-db-collection@latest @powersync/react-native@latest

--- a/skills/powersync/references/sdks/powersync-js-vue.md
+++ b/skills/powersync/references/sdks/powersync-js-vue.md
@@ -31,7 +31,7 @@ Vue-specific integration for the PowerSync JavaScript SDK. Use this reference al
 npm install @powersync/vue@latest
 
 # pnpm (must install peer dependencies explicitly)
-pnpm add @powersync/vue@latest @powersync/web@latest @journeyapps/wa-sqlite@latest
+pnpm add @powersync/vue@latest @powersync/web@latest
 ```
 
 ### 2. Plugin Setup

--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -52,7 +52,7 @@ Framework-specific files (load alongside this file):
 ## Package Coverage
 
 | Need | Package |
-|------|---------|
+|------|--------|
 | Web browser | `@powersync/web` |
 | React Native | `@powersync/react-native` |
 | Node.js/CLI | `@powersync/node` |
@@ -71,7 +71,6 @@ Framework-specific files (load alongside this file):
 ```bash
 # Web
 npm install @powersync/web@latest
-npm install @journeyapps/wa-sqlite@latest # Needed (peer-dependency)
 
 # React Native
 npm install @powersync/react-native@latest
@@ -689,7 +688,7 @@ subscription.unsubscribe();
 These advanced topics are in separate files — load only when needed:
 
 | Topic | File | Load when… |
-|-------|------|-----------|
+|-------|------|----------|
 | Drizzle / Kysely ORM | `references/sdks/powersync-js-orm.md` | Using Drizzle or Kysely for type-safe queries |
 | Raw Tables | `references/raw-tables.md` | Need native SQLite tables (SDK-agnostic — JS, Dart, Kotlin, Swift, Rust) |
 


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/550

### What changed in docs

With `@powersync/web` v2.1.0, `@journeyapps/wa-sqlite` is no longer a peer dependency and does not need to be installed manually. The docs PR removed it from all install commands across Next.js, TanStack, Capacitor, and the core web snippet.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-js.md`: Removed `@journeyapps/wa-sqlite@latest` from the web install block in the Quick Setup section.
- `skills/powersync/references/sdks/powersync-js-tanstack.md`: Removed `@journeyapps/wa-sqlite@latest` from the TanStack DB web install command.
- `skills/powersync/references/sdks/powersync-js-react.md`: Removed `@journeyapps/wa-sqlite@latest` from the Next.js install command.
- `skills/powersync/references/sdks/powersync-js-vue.md`: Removed `@journeyapps/wa-sqlite@latest` from the Vue pnpm install command.

### Notes for reviewer

The Vite `optimizeDeps.exclude` config in `powersync-js-react.md` still lists `@journeyapps/wa-sqlite`. The docs PR did not change any Vite configuration, so this was left untouched. If the package is now bundled inside `@powersync/web` and is never a direct dependency, keeping it in `exclude` is harmless but potentially misleading. A reviewer familiar with the Vite build behavior should decide whether to remove it.

The Nuxt pnpm install in `powersync-js-vue.md` did not include `@journeyapps/wa-sqlite` before this PR, so no change was needed there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPyJj7WzZWiStegbEJRZuz)_