### PR TITLE
Sync from docs: add inline multiple client versions guidance (powersync-docs #551)

### DIFF
--- a/skills/powersync/references/sync-config.md
+++ b/skills/powersync/references/sync-config.md
@@ -442,6 +442,49 @@ Reference these when the standard patterns don't cover your use case:
 | [Sharded Databases](https://docs.powersync.com/sync/advanced/sharded-databases.md) | Source data from multiple database shards |
 | [Compatibility Flags](https://docs.powersync.com/sync/advanced/compatibility) | Fix known SQL expression edge cases in Sync Streams; if `NOT NULL`, `substr()`, or `length()` behave unexpectedly, `unstable_sqlite_expression_engine` (Service ≥ 1.22.0, experimental — may be removed) routes evaluation through actual SQLite |
 
+### Multiple Client Versions
+
+When a schema change breaks older app versions still in use (for example, renaming or restructuring a table), define separate stream versions so each client receives the schema it expects.
+
+If the affected stream is manually subscribed (no `auto_subscribe: true`), prefer versioning by stream name. Define a new stream alongside the old one. New app versions subscribe to the new stream by name; older versions continue subscribing to the old stream. Remove the old stream once those versions are no longer in use.
+
+```yaml
+streams:
+  # Old stream, kept for backward compatibility.
+  # Remove once older app versions are no longer in use.
+  user_assets:
+    query: SELECT * FROM assets WHERE user_id = auth.user_id()
+
+  # New app versions subscribe to this stream.
+  # The alias maps the source table to the new client-side name.
+  user_assets_v2:
+    query: SELECT * FROM assets AS assets_v2 WHERE user_id = auth.user_id()
+```
+
+```js
+// New app versions subscribe to the new stream
+const subscription = await db.syncStream('user_assets_v2').subscribe();
+```
+
+If the stream uses `auto_subscribe: true`, clients cannot choose a stream by name. Use connection parameters instead: each client passes its version on connect, and stream queries filter on it.
+
+```yaml
+streams:
+  user_assets:
+    auto_subscribe: true
+    query: SELECT * FROM assets
+           WHERE user_id = auth.user_id()
+             AND connection.parameter('schema_version') = '1'
+
+  user_assets_v2:
+    auto_subscribe: true
+    query: SELECT * FROM assets AS assets_v2
+           WHERE user_id = auth.user_id()
+             AND connection.parameter('schema_version') = '2'
+```
+
+See [Multiple Client Versions](https://docs.powersync.com/sync/advanced/multiple-client-versions.md) for full details including the legacy Sync Rules approach.
+
 ## Convex-Specific Patterns
 
 If the source database is Convex, apply these adjustments when writing Sync Streams:


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/551

### What changed in docs

PR #551 added a new "Versioning by Stream Name" section to the Multiple Client Versions page, making it the preferred approach for schema changes that affect manually subscribed streams. Previously the page only documented the connection parameters approach. The PR also added `uploadData` examples for Capacitor and Node.js tabs (previously empty), and made editorial rewrites to the Sync Streams overview intro.

### Skill updates in this PR

- `skills/powersync/references/sync-config.md`: Added a `### Multiple Client Versions` subsection under Advanced Topics with inline guidance. If a stream is manually subscribed, define a new versioned stream alongside the old one and have new app versions subscribe to it by name. If the stream uses `auto_subscribe: true`, clients cannot choose by name, so use connection parameters filtered per stream instead.

### Notes for reviewer

The `uploadData` link corrections (SDK reference pages now point to the usage-examples page) and the new Capacitor/Node.js `uploadData` examples were not carried into any skill file. The pattern is the same across SDKs and is already covered in `custom-backend.md`. No new behavioral guidance was added there.

The Multiple Client Versions section in `sync-config.md` previously existed only as a table row with a link. This PR adds inline guidance so an agent can apply the pattern without fetching external docs.

The Sync Streams overview intro rewrite is editorial only and has no skill counterpart.

---
_Generated by [Claude Code](https://claude.ai/code/session_0163BT3yLHs5qHpnBMqx8abu)_