### PR TITLE
Sync from docs: update .NET SQLite extensions with SqliteExtension type and LoadPowerSyncExtension option (powersync-docs #553)

### DIFF
--- a/skills/powersync/references/sqlite-extensions.md
+++ b/skills/powersync/references/sqlite-extensions.md
@@ -2,7 +2,7 @@
 name: powersync-sqlite-extensions
 description: Loading custom SQLite extensions (vector search, FTS5 tokenizers, etc.) with PowerSync across all SDKs and platforms
 metadata:
-  tags: sqlite, extensions, vector-search, sqlite-vec, fts5, loadExtension, PersistentConnectionFactory, MDSQLiteOptions, wa-sqlite, wasm, dart-ffi, cinterops, custom-extension
+  tags: sqlite, extensions, vector-search, sqlite-vec, fts5, loadExtension, PersistentConnectionFactory, MDSQLiteOptions, LoadPowerSyncExtension, SqliteExtension, wa-sqlite, wasm, dart-ffi, cinterops, custom-extension
 ---
 
 # SQLite Extensions with PowerSync
@@ -118,7 +118,9 @@ Platform-specific bundling:
 
 ## .NET
 
-Pass extension file paths via `MDSQLiteOptions.Extensions`. You are responsible for building and bundling the extension files so they are resolvable at the paths you provide.
+Set `MDSQLiteOptions.Extensions` to an array of `SqliteExtension` objects to load custom extensions. You are responsible for building and bundling extension files so they can be loaded.
+
+If you need to disable auto-loading of the PowerSync core extension, set `MDSQLiteOptions.LoadPowerSyncExtension` to `false`. When doing so, one of the extensions in `MDSQLiteOptions.Extensions` must contain a build of the PowerSync core extension. Running the .NET SDK without the core extension, or with an outdated version, is not supported.
 
 ## Rust / Tauri
 


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/553

### What changed in docs

The .NET section of the SQLite extensions page was updated to clarify that `MDSQLiteOptions.Extensions` takes an array of `SqliteExtension` objects (not generic file paths), and to document the new `MDSQLiteOptions.LoadPowerSyncExtension` field, which controls whether the SDK auto-loads the PowerSync core extension.

### Skill updates in this PR

- `skills/powersync/references/sqlite-extensions.md`: Replaced "Pass extension file paths" with the correct `SqliteExtension` object type. Added a rule covering `MDSQLiteOptions.LoadPowerSyncExtension = false` and the constraint that the core extension must still be present. Added `LoadPowerSyncExtension` and `SqliteExtension` to the metadata tags.

### Notes for reviewer

The docs warning about running without the core extension is reproduced as an inline prose constraint, which fits the conditional-rule style of the skill. No new skill files were needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015nivbGtq1kyMqFVD7KMRwm)_