### PR TITLE
Sync from docs: document Flushed replication log entry format (powersync-docs #558)

### DIFF
--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -207,6 +207,23 @@ Put a timestamp in the data. When a row is written or updated in the source data
 
 Check the **Replication Lag** chart in the **Metrics** view of the [PowerSync Dashboard](https://dashboard.powersync.com/). Replicator logs in the **Logs** view surface errors that cause delays at this stage.
 
+When the user shares instance logs from the **Logs** view, look for `Flushed` entries. Each entry records one batch written to bucket storage and is the most direct view of replication throughput:
+
+```
+Flushed: 1200 ops, 30 index entries, 450 records. 512kb in 240ms. Last op_id: 88421. Replication lag: 3s
+```
+
+Structured log properties are available under `flushed` on each entry:
+
+| Property | What it measures |
+|----------|------------------|
+| `bucket_ops_count` | Operations appended to bucket operation history. One source row produces one operation per bucket it belongs to; rows shared across many buckets produce many operations. |
+| `parameter_indexes_count` | Parameter index entries written for rows feeding stream parameters. |
+| `source_records_count` | Source rows persisted with their bucket and lookup memberships. |
+| `size` | Flush size in bytes. |
+| `duration` | Write time in milliseconds. |
+| `replication_lag_seconds` | Age of the oldest uncommitted change in this batch, in seconds. Only present when the Service can determine this value. |
+
 For source-specific guidance (Postgres, MongoDB, MySQL, SQL Server) see [Replication Lag](https://docs.powersync.com/maintenance-ops/replication-lag) and [Replication Lag Debugging (Postgres)](#replication-lag-debugging-postgres) below.
 
 ### Stage 2: PowerSync Service to Client


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/558

### What changed in docs

Added a "Replication Batches" section to the PowerSync Service architecture page explaining how the Service batches and flushes replicated changes to bucket storage. Added a "Replication Flush Entries" section to the monitoring page documenting the `Flushed` log entry format and its structured properties (`bucket_ops_count`, `parameter_indexes_count`, `source_records_count`, `size`, `duration`, `replication_lag_seconds`).

### Skill updates in this PR

- `skills/powersync/references/powersync-debug.md`: Added `Flushed` log entry reference and property table under "Stage 1: Source Database to PowerSync Service" so agents can interpret instance logs when helping diagnose replication throughput.

### Notes for reviewer

The "Replication Batches" architecture content (describing bucket operations, parameter index entries, and source records) was not added to `powersync-service.md`. That file focuses on service configuration rather than operational troubleshooting, and the architectural detail does not change how an agent would configure or write code against PowerSync. If there is value in having agents understand why high bucket fan-out produces many operations, that context could be added to the `powersync-service.md` observability section in a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3g7NLxKqAHaS4j22mSHo)_