### PR TITLE
Sync from docs: add Checkpoint Requests API to Swift SDK reference (powersync-docs #549)

### DIFF
--- a/skills/powersync/references/sdks/powersync-swift.md
+++ b/skills/powersync/references/sdks/powersync-swift.md
@@ -1,8 +1,8 @@
 ---
 name: powersync-swift
-description: PowerSync Swift SDK: schema, queries, sync lifecycle, backend connectors, GRDB ORM support, and Swift Data community integration
+description: PowerSync Swift SDK: schema, queries, sync lifecycle, checkpoint requests, backend connectors, GRDB ORM support, and Swift Data community integration
 metadata:
-  tags: swift, ios, macos, grdb, orm, sqlite, offline-first, swift-data
+  tags: swift, ios, macos, grdb, orm, sqlite, offline-first, swift-data, checkpoint-requests
 ---
 
 # PowerSync Swift SDK
@@ -140,6 +140,75 @@ See [Instantiate the PowerSync Database](https://docs.powersync.com/client-sdks/
 ## Sync Streams
 
 See [sync-config.md](references/sync-config.md) for how to subscribe to Sync Streams when `auto_subscribe` is not set to `true` in the PowerSync Service config.
+
+## Checkpoint Requests (Alpha)
+
+Checkpoint requests let you confirm that the local database has caught up to a specific server state. Use this when you need to know that server changes are available locally: after a local write to wait for the result to sync back, in a pull-to-refresh flow, or when a user opens a link that refers to data that may not have synced yet.
+
+Requires Swift SDK v1.16.0+, PowerSync Service v1.24.0+, and `checkpointMode: .requests()` set in `ConnectOptions`. Support for other SDKs is planned.
+
+```swift
+try await database.connect(
+    connector: connector,
+    options: ConnectOptions(checkpointMode: .requests())
+)
+```
+
+Checkpoint requests are opt-in. Without `checkpointMode: .requests()`, calling `requestCheckpoint()` throws an error.
+
+### Waiting for the Latest Server Data
+
+Create a checkpoint request, then wait for it to resolve before reading the refreshed data:
+
+```swift
+let checkpoint = try await database.requestCheckpoint()
+try await checkpoint.waitForSync(timeout: 30)
+// Local queries now reflect server state from when requestCheckpoint() was called.
+```
+
+`requestCheckpoint()` requires that the database is connected or connecting. If offline, the call suspends until the Service is reachable. Cancel the calling task to stop waiting. The `timeout` passed to `waitForSync(timeout:)` only limits waiting for the checkpoint to apply locally.
+
+### Error Handling
+
+Handle request creation and waiting errors separately when your app needs different recovery behavior:
+
+```swift
+do {
+    let checkpoint = try await database.requestCheckpoint()
+    try await checkpoint.waitForSync(timeout: 30)
+} catch CheckpointWaitError.timeout {
+    showRefreshMessage("The refresh timed out. Try again.")
+} catch CheckpointWaitError.disconnected {
+    showRefreshMessage("Reconnect before refreshing again.")
+} catch let error as any CheckpointError {
+    showRefreshMessage(error.localizedDescription)
+}
+```
+
+A request remains valid across a disconnect. After reconnecting with `.requests()`, call `waitForSync()` again on the same request. Discard request values after clearing the local PowerSync database, because clearing resets the persisted request state.
+
+`waitForSync()` also fails if the sync client reports an upload or download error. Wait for sync to recover before retrying.
+
+### Relationship to Local Writes
+
+When `.requests()` mode is enabled, the SDK creates an internal request after each upload queue flush. You do not need to call `requestCheckpoint()` for your own writes. If you create a request while writes are pending, waiting on it also waits for those writes to upload and their results to sync back:
+
+```swift
+try await database.execute(
+    sql: "INSERT INTO tasks (id, description) VALUES (uuid(), ?)",
+    parameters: ["Review the project plan"]
+)
+
+let checkpoint = try await database.requestCheckpoint()
+try await checkpoint.waitForSync(timeout: 30)
+// The pending write has uploaded and its server state has synced locally.
+```
+
+This behavior relies on `uploadData()` returning only after your backend has committed the uploaded changes to the source database.
+
+### Async Upload Backends (Team/Enterprise)
+
+If `uploadData()` queues writes for later processing rather than committing them synchronously, use `CustomCheckpointRequestConnector`. This requires a `checkpoint_requests` event definition in your sync config and is available on [Team and Enterprise](https://www.powersync.com/pricing) plans. See [Checkpoint Requests](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests) for the full setup guide.
 
 ## Query Patterns
 


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/549

### What changed in docs

Added a new "Checkpoint Requests" page documenting an alpha API that lets Swift apps confirm the local database has caught up to a specific server state. The API is Swift-only and requires PowerSync Service v1.24.0+. The PR also updated the consistency, custom write checkpoints, and feature status pages to reference the new feature.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-swift.md`: Added "Checkpoint Requests (Alpha)" section covering the `checkpointMode: .requests()` connect option, `requestCheckpoint()` and `waitForSync(timeout:)` usage, error handling for `CheckpointWaitError.timeout` and `CheckpointWaitError.disconnected`, the relationship to local writes (the SDK creates an internal request after each upload flush, so no explicit call is needed for your own writes), and a pointer to `CustomCheckpointRequestConnector` for Team/Enterprise async backends.

### Notes for reviewer

The `checkpoint_requests` sync config event (used by `CustomCheckpointRequestConnector` for async upload backends) is Team/Enterprise only and alpha. Neither `sync-config.md` nor `custom-backend.md` currently documents the `event_definitions` concept, so adding it here would introduce a larger pattern with uncertain scope. A follow-up PR could add that once the feature is out of alpha.

The docs PR also added a one-line pointer in `consistency.mdx` and marked the feature as Alpha in `feature-status.mdx`. Neither has a skill counterpart.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpgwvuYSoajhehmok9y3D1)_