### PR TITLE
Sync from docs: add .NET API reference URL to skill (powersync-docs #561)

### DIFF
--- a/skills/powersync/references/sdks/powersync-dotnet.md
+++ b/skills/powersync/references/sdks/powersync-dotnet.md
@@ -622,6 +622,7 @@ Only read these if the content above does not provide enough context for the tas
 
 - [NuGet packages](https://www.nuget.org/profiles/PowerSync) — published packages
 - [Full SDK reference](https://docs.powersync.com/client-sdk-references/dotnet.md) — full SDK documentation
+- [API reference](https://powersync-ja.github.io/powersync-dotnet/api/PowerSync.html) — generated API docs for all SDK types, methods, and properties
 - [CommandLine](https://github.com/powersync-ja/powersync-dotnet/tree/main/demos/CommandLine) — CLI app with real-time data sync example
 - [WPF](https://github.com/powersync-ja/powersync-dotnet/tree/main/demos/WPF) — Windows desktop to-do list app example
 - [MAUITodo](https://github.com/powersync-ja/powersync-dotnet/tree/main/demos/MAUITodo) — Cross-platform mobile and desktop to-do list example


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/561

### What changed in docs

The .NET SDK now has a published API reference at https://powersync-ja.github.io/powersync-dotnet/api/PowerSync.html. Docs PR #561 adds a dedicated page for it, updates inline method links from GitHub source to official API docs, and corrects the Watch example in the setup guide to use the `IAsyncEnumerable` and `CancellationTokenSource` pattern.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-dotnet.md`: Added the official API reference URL to Additional Resources.

### Notes for reviewer

The Watch pattern (`IAsyncEnumerable` with `CancellationTokenSource`) and the `IPowerSyncBackendConnector` interface name were already correct in the skill before this PR. No changes were needed for those items.

PR #562 ("Add migration guide from Electric Cloud") also merged today and has no corresponding agent-skills PR. That PR adds a concept comparison table (Electric Shapes vs Sync Streams covering definition model, authorization, client store, writes, and primary key requirements) and a step-by-step JS/TS migration guide. A new skill file or a section in an existing one may be warranted. This run covers only #561 per the one-PR-per-run policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHH3WqyQN51B4bQsyRjedB)_