### PR TITLE
Sync from docs: add SQLite performance optimization page and prepared statement cache (powersync-docs #566)

### DIFF
--- a/skills/powersync/references/sdks/powersync-dart.md
+++ b/skills/powersync/references/sdks/powersync-dart.md
@@ -124,6 +124,23 @@ Future<void> disconnect() async {
 
 See [Instantiate the PowerSync Database](https://docs.powersync.com/client-sdks/reference/flutter.md#2-instantiate-the-powersync-database) for more information.
 
+### SQLite Options
+
+Pass `SqliteOptions` to tune low-level SQLite behavior:
+
+```dart
+db = PowerSyncDatabase(
+  schema: schema,
+  path: path,
+  sqliteOptions: SqliteOptions(
+    preparedStatementCacheSize: 64, // LRU cache per connection; omit to disable
+    maxReaders: 5,                  // Max concurrent read connections (default: 5)
+  ),
+);
+```
+
+If statement preparation overhead is visible in profiling, set `preparedStatementCacheSize` to a non-zero value. Each connection keeps its own independent LRU cache up to that size. For the JS SDK equivalent, see `database.preparedStatementsCache`. See the [API reference](https://pub.dev/documentation/powersync/latest/sqlite_async/SqliteOptions/preparedStatementCacheSize.html) for details.
+
 ## Sync Streams
 
 See [sync-config.md](references/sync-config.md) for how to subscribe to Sync Streams when `auto_subscribe` is not set to `true` in the PowerSync Service config.

--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -293,7 +293,8 @@ const db = new PowerSyncDatabase({
   schema,
   database: {
     dbFilename: 'app.db',
-    debugMode: true        // Logs all SQL to Chrome DevTools Performance timeline
+    debugMode: true,              // Logs all SQL to Chrome DevTools Performance timeline
+    preparedStatementsCache: 64,  // LRU cache size per connection; omit to disable
   },
   flags: {
     useWebWorker: true,    // Default true — runs DB in a web worker
@@ -301,6 +302,8 @@ const db = new PowerSyncDatabase({
   }
 });
 ```
+
+If statement preparation overhead appears in profiling, set `preparedStatementsCache` to a non-zero value. Each connection maintains its own independent LRU cache up to that size. For the Dart SDK equivalent, see `SqliteOptions.preparedStatementCacheSize`. See the [API reference](https://powersync-ja.github.io/powersync-js/web-sdk/globals#preparedStatementsCache-1) for details.
 
 Multi-tab behavior: By default the web SDK uses a shared sync worker so all tabs share sync state. Only the most recently opened tab runs `fetchCredentials` and `uploadData`. Disable with `enableMultiTabs: false` if causing issues — but then only the oldest tab syncs.
 


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/566

### What changed in docs

Added a new "SQLite Performance Optimization" page under the Client SDKs Advanced section, covering SDK defaults (WAL, page cache, synchronous pragma), `debugMode` query tracing, connection pool sizing, watched query throttling, and a prepared statement cache option for the JS Web and Dart SDKs. The existing troubleshooting page dropped its inline "Web: Logging Queries on the Performance Timeline" section and now links to the new page instead.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-js.md`: Added `preparedStatementsCache` to the Web-Specific Options code block and a conditional note on when to enable it, how each connection maintains its own LRU cache, and the Dart equivalent.
- `skills/powersync/references/sdks/powersync-dart.md`: Added a "SQLite Options" subsection showing `SqliteOptions` with `preparedStatementCacheSize` and `maxReaders`, with a conditional note on when to enable the prepared statement cache and the JS equivalent.

### Notes for reviewer

The new docs page covers a broader set of optimization strategies (watched query throttling, High Performance Diffs, indexes, Raw Tables) beyond the two config options changed here. A dedicated `skills/powersync/references/powersync-performance.md` file could eventually cover those strategies in rule-based form, similar to how `powersync-debug.md` covers diagnostics. That gap is left for a future decision rather than scaffolded as a stub here.

The `debugMode` flag is already documented in `powersync-js.md` (Web-Specific Options) and in `powersync-debug.md`, so no change was needed there.

`maxReaders` (Dart) is an existing `SqliteOptions` field, not new from this PR. It was added alongside `preparedStatementCacheSize` to make the `SqliteOptions` example useful to an agent. Drop it if the reviewer prefers strictly minimal scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkXgr2m92bVcSJPFDdcsP2)_