### PR TITLE
Sync from docs: add InMemoryWriteAheadLogPool VFS option (powersync-docs #567)

### DIFF
--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -52,7 +52,7 @@ Framework-specific files (load alongside this file):
 ## Package Coverage
 
 | Need | Package |
-|------|---------|
+|------|--------|
 | Web browser | `@powersync/web` |
 | React Native | `@powersync/react-native` |
 | Node.js/CLI | `@powersync/node` |
@@ -310,6 +310,7 @@ Multi-tab behavior: By default the web SDK uses a shared sync worker so all tabs
 |---------------------------|---------------------|---------------------------------------------------------------------------------------------------------|
 | IDBBatchAtomicVFS         | Default             | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#1-idbbatchatomicvfs-default)     |
 | OPFSCoopSyncVFS           | Recommended         | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#2-opfs-based-alternatives)       |
+| InMemoryWriteAheadLogPool | Experimental — multi-threaded, in-memory; no persistence; requires cross-origin isolation | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#multi-threaded-in-memory-vfs) |
 
 ```ts
 // Recommended — more reliable across browsers including Safari
@@ -325,6 +326,31 @@ const db = new PowerSyncDatabase({
 ```
 
 Safari: Requires `OPFSCoopSyncVFS` for stable multi-tab, or set `useWebWorker: false`. See [Web SDK Reference](https://docs.powersync.com/client-sdks/reference/javascript-web.md) for full configuration options.
+
+#### InMemoryWriteAheadLogPool (Experimental, v2.2.0+)
+
+Use `InMemoryWriteAheadLogPool` only when all of the following hold:
+- The app needs highly concurrent, high-performance queries.
+- The actively synced dataset is small (re-synced on every tab open).
+- Persistence is not required (data is lost when the tab closes).
+- Cross-origin isolation headers (`Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`) can be enabled. Without `SharedArrayBuffer` support, the constructor throws.
+- Multiple tabs do not need to share offline state. Each tab opens an isolated database that cannot be named.
+
+If any condition does not hold, use `OPFSCoopSyncVFS` or the default `IDBBatchAtomicVFS` instead.
+
+Not bundled with `@powersync/web` — import from `@powersync/web/in-memory-wal-experiment` to avoid bundle size impact on apps that do not use it:
+
+```ts
+import { InMemoryWriteAheadLogPool } from '@powersync/web/in-memory-wal-experiment';
+import { PowerSyncDatabase } from '@powersync/web';
+
+const db = new PowerSyncDatabase({
+  schema: AppSchema,
+  opened: new InMemoryWriteAheadLogPool({
+    numWorkers: 3, // One writer, two additional read workers
+  }),
+});
+```
 
 ## Query Patterns
 
@@ -689,7 +715,7 @@ subscription.unsubscribe();
 These advanced topics are in separate files — load only when needed:
 
 | Topic | File | Load when… |
-|-------|------|-----------|
+|-------|------|----------|
 | Drizzle / Kysely ORM | `references/sdks/powersync-js-orm.md` | Using Drizzle or Kysely for type-safe queries |
 | Raw Tables | `references/raw-tables.md` | Need native SQLite tables (SDK-agnostic — JS, Dart, Kotlin, Swift, Rust) |
 


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/567

### What changed in docs

Documents `InMemoryWriteAheadLogPool`, an experimental multi-threaded in-memory VFS added in `@powersync/web` 2.2.0. The pool uses `SharedArrayBuffer` to coordinate an in-memory SQLite database across workers and requires cross-origin isolation headers to function.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-js.md`: Added `InMemoryWriteAheadLogPool` to the VFS options table and added a conditional usage section with the five conditions that must all hold before recommending it, plus the correct import path and a minimal usage example.

### Notes for reviewer

`drift/docs-538-in-memory-vfs` is an existing branch in this repo that modifies the same file to add a different VFS type, `WASQLiteVFS.InMemoryVFS`. That branch has no open PR. If it is merged after this one, there will be a merge conflict in the VFS table. The two options are distinct: `InMemoryVFS` uses a shared worker and the standard `WASQLiteOpenFactory` interface; `InMemoryWriteAheadLogPool` is a separate experimental pool that requires `SharedArrayBuffer` and cross-origin isolation.

PR #566 ("Add page on client performance, caching prepared statements") was also merged today and introduces `preparedStatementsCache` (JS) and `preparedStatementCacheSize` (Dart) options not covered in any skill file. A branch `drift/docs-566-client-performance` exists for it with no open PR. That gap should be addressed in a separate agent-skills PR rather than bundled here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiKuduitLDy9XDrrRhB4Ah)_