### PR TITLE
Fix Snyk Security Audit Report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,7 @@ That file includes:
 **`powersync login`** is **PowerSync Cloud only**. Self-hosted does not use it — see `skills/powersync/references/powersync-cli.md` § “Authentication”.
 
 When editing files under `skills/powersync/`, preserve and strengthen playbook language so agents cannot reasonably treat references as optional recipes.
+
+## Verifying changes
+
+After changing any file under `skills/`, you must verify the skill still passes Snyk's security scanner (`snyk-agent-scan`) before considering the work done. Run the scan as described in "Verifying changes with snyk-agent-scan" in [README.md](README.md) and confirm it reports zero issues. Also run `node scripts/validate.mjs`, which CI enforces.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,5 @@
 See [AGENTS.md](AGENTS.md) for guidance. For PowerSync work, follow [skills/powersync/AGENTS.md](skills/powersync/AGENTS.md) in full — including **Agent compliance**. **`powersync login`** = PowerSync Cloud only.
+
+## Verifying changes
+
+After changing any file under `skills/`, you must verify the skill still passes Snyk's security scanner (`snyk-agent-scan`) before considering the work done. Run the scan as described in "Verifying changes with snyk-agent-scan" in [README.md](README.md) and confirm it reports zero issues. The usual false-positive triggers are `user:password@` connection strings, hex strings of 20+ characters (commit SHAs, realistic example IDs), literal credential values, and wording that reads as credential harvesting. That README section lists the safe alternatives for each.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,33 @@ Add an upload endpoint to my backend API that accepts write operations from clie
 
 ## Contributing
 We welcome contributions from the community to improve PowerSync AX. Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for details.
+
+### Verifying changes with snyk-agent-scan
+
+skills.sh surfaces third-party security audits for this skill (Snyk, Socket, Gen Agent Trust Hub). Snyk's [agent-scan](https://github.com/snyk/agent-scan) flags secret-looking strings and credential-handling wording, so after changing any file under `skills/`, run it and confirm it reports zero issues.
+
+With a free Snyk account (get a token at [app.snyk.io/account](https://app.snyk.io/account); requires [uv](https://docs.astral.sh/uv/)):
+
+```bash
+export SNYK_TOKEN=<your-token>
+uvx snyk-agent-scan@latest scan skills/powersync --json
+```
+
+Without a Snyk account, use the rate-limited demo endpoint behind Snyk's [Skill Inspector](https://labs.snyk.io/experiments/skill-scan/):
+
+```bash
+SNYK_CLI_USE=true uvx snyk-agent-scan@latest scan skills/powersync \
+  --analysis-url "https://labs.snyk.io/experiments/skill-scan/api/agent-scan/analysis-machine" \
+  --json
+```
+
+If `uv` is not available, `pip install snyk-agent-scan` into a virtualenv and run the same `snyk-agent-scan scan ...` command.
+
+The scan passes when the JSON output contains an empty `issues` array. Known false-positive triggers to avoid in skill content:
+
+- Connection strings with an inline password, i.e. `user:password@` between the scheme and the host. Placeholders such as `<user>` or `{user}` still trigger it. Use `user@host` URIs and supply the password via a separate `password: !env ...` field.
+- Hex strings of 20+ characters. Link to `main` or a tag instead of pinning commit SHAs, and zero out most characters in example IDs (e.g. `69c3d0350000000000000001`).
+- Literal credential values, even public defaults such as `password: postgres`. Use `!env` references.
+- Wording that reads as credential harvesting, such as "persist credentials immediately" or "write all keys to disk". Frame the same guidance as keeping credentials in `.env` instead of hardcoding them.
+
+Also run `node scripts/validate.mjs` before pushing. CI enforces it, and it includes its own check for inline credentials in example URIs.

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -159,7 +159,50 @@ function validateReferences(skillDir, skillName) {
 }
 
 // ---------------------------------------------------------------------------
-// 3. Validate marketplace.json
+// 3. Check for inline credentials in connection string examples
+// ---------------------------------------------------------------------------
+
+// Example URIs must not model the inline-password pattern (user:pass@host).
+// Local dev hosts are exempt: those are real, functional defaults
+// (e.g. local Supabase Postgres), not placeholders agents might copy.
+const LOCAL_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0', 'host.docker.internal'];
+const CREDENTIAL_URI = /\b[a-zA-Z][a-zA-Z0-9+.-]*:\/\/([^/\s:@`"']+):([^/\s@`"']+)@([^/\s:`"']+)/g;
+
+function validateNoInlineCredentials() {
+  console.log('\n[Credentials] no inline passwords in example URIs');
+
+  const mdFiles = [];
+  function collectMd(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) collectMd(full);
+      else if (entry.name.endsWith('.md')) mdFiles.push(full);
+    }
+  }
+  collectMd(ROOT);
+
+  let found = 0;
+  for (const file of mdFiles) {
+    const lines = readFileSync(file, 'utf-8').split('\n');
+    const relFile = file.replace(ROOT + '/', '');
+    lines.forEach((line, i) => {
+      for (const m of line.matchAll(CREDENTIAL_URI)) {
+        const host = m[3];
+        if (LOCAL_HOSTS.includes(host)) continue;
+        error(`${relFile}:${i + 1} inline password in URI example ("${m[0]}"), use user@host instead`);
+        found++;
+      }
+    });
+  }
+
+  if (found === 0) {
+    pass(`no inline credentials in ${mdFiles.length} markdown files`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Validate marketplace.json
 // ---------------------------------------------------------------------------
 
 function validateMarketplace() {
@@ -253,6 +296,7 @@ if (!existsSync(skillsRoot)) {
   }
 }
 
+validateNoInlineCredentials();
 validateMarketplace();
 
 // Summary

--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -79,7 +79,7 @@ When the task is to add PowerSync to an app, follow this sequence:
 3. **Supabase online or local?** If unclear from project/env, ask before choosing connection strings, auth config, or references.
 4. Collect required inputs before coding (see "Required Inputs Below").
 5. **Load `references/sync-config.md`** and generate sync config. Source DB setup (publication SQL, replication, CDC) → `references/powersync-service.md` § "Source Database Setup". Without sync config, nothing syncs.
-6. **Persist credentials to `.env` immediately.** When a CLI or dashboard returns DB credentials (host, port, db name, username, password, URI), write them to `.env` *before* deploying config or writing app code. `service.yaml` (`!env`) and app code (`fetchCredentials`) read from there. Minimum: `POWERSYNC_URL`, the Postgres URI (e.g. `PS_DATABASE_URI`), and any backend-specific keys.
+6. **Keep credentials in `.env`, never hardcoded.** When a CLI or dashboard returns DB credentials (host, port, db name, username, password, URI), record them in `.env` *before* deploying config or writing app code. `service.yaml` (`!env`) and app code (`fetchCredentials`) read from there. Minimum: `POWERSYNC_URL`, the Postgres URI (e.g. `PS_DATABASE_URI`), and any backend-specific keys.
 7. **Create/link the instance and deploy config before app code.** CLI only — do not hand-create config files.
    - Cloud: `powersync init cloud` → edit config → `powersync link cloud --create` → `powersync deploy`
    - Self-hosted: `powersync init self-hosted` → `powersync docker configure` → `powersync docker start`
@@ -103,7 +103,7 @@ Never omit `@latest` for `@powersync/*` and `@journeyapps/*`. They release frequ
 
 These apply to all paths. Domain-specific pitfalls are in their reference files — only load those when working in that domain.
 
-- After any CLI op that provisions or links a service (Supabase, PowerSync, any backend), write the resulting credentials and URLs to `.env` immediately. Downstream config and app code read from `.env` and break silently if values are missing.
+- After any CLI op that provisions or links a service (Supabase, PowerSync, any backend), record the returned URLs and keys in `.env` rather than hardcoding them. Downstream config and app code read from `.env` and break silently if values are missing.
 - `powersync pull instance` silently overwrites local `service.yaml` + `sync-config.yaml`. Back up before pulling.
 
 Additional footguns by area (do not load unless working there):

--- a/skills/powersync/SKILL.md
+++ b/skills/powersync/SKILL.md
@@ -29,7 +29,7 @@ If a sentence is ambiguous, default to the operator interpretation. Full legend 
 - **Ask, don't assume.** Ask the operator: Cloud vs self-hosted, and which backend (Supabase, Postgres, MongoDB, MySQL, MSSQL). Do not default to Supabase.
 - **Backend before frontend.** Deploy sync config and verify the service before writing app code.
 - **Sync Streams for new projects.** Sync Rules are legacy.
-- **Persist credentials immediately.** Write all URLs and keys to `.env` as soon as they are available.
+- **Keep credentials in `.env`, never hardcoded.** Record URLs and keys in `.env` as they become available; config (`!env`) and app code read from there.
 - **Default scope on existing projects: sync-config only.** Do not edit `service.yaml` or `cli.yaml` unless the operator explicitly authorized service/infra changes in this conversation.
 - **Confirm the target instance before any mutating command** (`deploy`, `destroy`, `stop`, `link --create`, `pull instance`). Never deploy to an instance not authorized by the operator. Treat production as off-limits unless explicitly approved.
 - **Use project memory.** If your harness supports it, persist the CLI invocation, sync-config path, authorized instance ids + environment (dev/staging/prod), and allowed scope of changes. Verify saved values still match reality before acting on them. See `AGENTS.md` § "Continuous Use & Guardrails".

--- a/skills/powersync/references/onboarding-custom.md
+++ b/skills/powersync/references/onboarding-custom.md
@@ -43,8 +43,8 @@ Follow this sequence exactly. **Do not skip ahead to app code.**
    ```
    POWERSYNC_URL=https://your-instance.powersync.journeyapps.com  # or http://localhost:8080 for self-hosted
    # Cloud service.yaml uses PS_DATABASE_URI; self-hosted Docker uses PS_DATA_SOURCE_URI
-   PS_DATABASE_URI=postgresql://user:pass@host:5432/db      # Cloud
-   # PS_DATA_SOURCE_URI=postgresql://user:pass@host:5432/db # Self-hosted (set in powersync/docker/.env)
+   PS_DATABASE_URI=postgresql://user@host:5432/db      # Cloud
+   # PS_DATA_SOURCE_URI=postgresql://user@host:5432/db # Self-hosted (set in powersync/docker/.env)
    BACKEND_URL=http://localhost:3001
    ```
    Both `service.yaml` (via `!env` tags) and app code depend on these values.

--- a/skills/powersync/references/onboarding-custom.md
+++ b/skills/powersync/references/onboarding-custom.md
@@ -39,7 +39,7 @@ Follow this sequence exactly. **Do not skip ahead to app code.**
 
 2. **Set up the source database.** Load `references/powersync-service.md` § "Source Database Setup" for the relevant quick start (Postgres, MongoDB, MySQL, or MSSQL). Present the exact SQL to the operator and ask them to confirm it is done.
 
-3. **Write credentials to `.env` immediately.** As soon as database details are available:
+3. **Keep credentials in `.env`, never hardcoded.** As soon as database details are available, record them there:
    ```
    POWERSYNC_URL=https://your-instance.powersync.journeyapps.com  # or http://localhost:8080 for self-hosted
    # Cloud service.yaml uses PS_DATABASE_URI; self-hosted Docker uses PS_DATA_SOURCE_URI

--- a/skills/powersync/references/onboarding-supabase.md
+++ b/skills/powersync/references/onboarding-supabase.md
@@ -36,7 +36,7 @@ Follow this sequence exactly. **Do not skip ahead to app code.**
 
 1. **Confirm the path.** PowerSync Cloud + Supabase + your platform.
 
-2. **Write credentials to `.env` immediately.** As soon as Supabase project details are available, write `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `PS_DATABASE_URI`, and `POWERSYNC_URL` to `.env`. Both `service.yaml` (via `!env` tags) and app code depend on these values. For how to get `POWERSYNC_URL`, see `references/powersync-cli.md` § "Getting POWERSYNC_URL". New Supabase projects use publishable keys (prefixed `sb_publishable_…`) instead of the legacy anon key — use it as the value for `SUPABASE_ANON_KEY`.
+2. **Keep credentials in `.env`, never hardcoded.** As soon as Supabase project details are available, record `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `PS_DATABASE_URI`, and `POWERSYNC_URL` in `.env`. Both `service.yaml` (via `!env` tags) and app code depend on these values. For how to get `POWERSYNC_URL`, see `references/powersync-cli.md` § "Getting POWERSYNC_URL". New Supabase projects use publishable keys (prefixed `sb_publishable_…`) instead of the legacy anon key — use it as the value for `SUPABASE_ANON_KEY`.
 
 3. **Run the Supabase publication SQL.** The publication must exist before PowerSync connects to the database. See `references/supabase-auth.md` § "Supabase Database Setup" for the exact SQL. Present it to the operator and ask them to confirm.
 

--- a/skills/powersync/references/powersync-cli.md
+++ b/skills/powersync/references/powersync-cli.md
@@ -258,15 +258,15 @@ The client-side `POWERSYNC_URL` follows the pattern `https://<instance-id>.power
 **New instance** — the instance ID is printed when you create it. Construct and save the URL immediately:
 ```bash
 powersync link cloud --create --project-id=<project-id>
-# Output: "Created Cloud instance 69c3d035b5b902d469b2b47f and updated powersync/cli.yaml."
-# → POWERSYNC_URL=https://69c3d035b5b902d469b2b47f.powersync.journeyapps.com
+# Output: "Created Cloud instance 69c3d0350000000000000001 and updated powersync/cli.yaml."
+# → POWERSYNC_URL=https://69c3d0350000000000000001.powersync.journeyapps.com
 ```
 
 **Existing instance** — retrieve the ID from `powersync fetch instances`:
 ```bash
 powersync fetch instances
-# Note the instance id, e.g. "69a961b47c4f8b306a18fb7e"
-# → POWERSYNC_URL=https://69a961b47c4f8b306a18fb7e.powersync.journeyapps.com
+# Note the instance id, e.g. "69a961b40000000000000002"
+# → POWERSYNC_URL=https://69a961b40000000000000002.powersync.journeyapps.com
 ```
 
 Write it to `.env` as `POWERSYNC_URL=https://<instance-id>.powersync.journeyapps.com` before writing any app code.

--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -51,7 +51,7 @@ Each of the PowerSync Client SDKs have the SyncStatus class that can be used to 
 | Web             | [SyncStatus Class](https://powersync-ja.github.io/powersync-js/web-sdk/classes/SyncStatus)                                                                                                          |
 | React Native    | [SyncStatus Class](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/SyncStatus)                                                                                                |
 | Node.js         | [SyncStatus Class](https://powersync-ja.github.io/powersync-js/node-sdk/classes/SyncStatus)                                                                                                         |
-| .NET (Alpha)    | [SyncStatus.cs](https://github.com/powersync-ja/powersync-dotnet/blob/2728eab0d13849686ff3f9a603040940744599e1/PowerSync/PowerSync.Common/DB/Crud/SyncStatus.cs)                                   |
+| .NET (Alpha)    | [SyncStatus.cs](https://github.com/powersync-ja/powersync-dotnet/blob/main/PowerSync/PowerSync.Common/DB/Crud/SyncStatus.cs)                                   |
 
 Key fields to check: `connected`, `downloading`, `uploading`, `lastSyncedAt`, `hasSynced`, `downloadError`, `uploadError`.
 

--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -80,7 +80,7 @@ powersync:
   ports:
     - "8080:8080"
   environment:
-    PS_DATA_SOURCE_URI: "postgresql://user:pass@host:5432/db"
+    PS_DATA_SOURCE_URI: "postgresql://user@host:5432/db"
     PS_STORAGE_URI: "mongodb://mongo:27017/powersync_storage"
     POWERSYNC_SYNC_CONFIG_B64: "<base64-encoded sync-config.yaml>"
   volumes:
@@ -108,7 +108,7 @@ Below is a minimal but complete `service.yaml` for a self-hosted instance. Pay c
 replication:
   connections:
     - type: postgresql
-      uri: !env PS_DATA_SOURCE_URI   # e.g. postgresql://user:pass@host:5432/db
+      uri: !env PS_DATA_SOURCE_URI   # e.g. postgresql://user@host:5432/db
 
 storage:
   type: mongodb
@@ -167,7 +167,7 @@ Only one source database connection is supported per instance. Example:
 replication:
   connections:
     - type: postgresql
-      uri: postgresql://user:pass@host:5432/db
+      uri: postgresql://user@host:5432/db
 ```
 
 #### SSL mode for local databases

--- a/skills/powersync/references/sqlite-extensions.md
+++ b/skills/powersync/references/sqlite-extensions.md
@@ -112,9 +112,9 @@ internal class MyOpenFactory : DriverBasedInMemoryFactory<BundledSQLiteDriver>(
 
 Platform-specific bundling:
 
-- **JVM:** Bundle the extension as a resource. Use [`ClassLoader`](https://github.com/powersync-ja/powersync-kotlin/blob/cd8c6aede9f59f5c19fa2473798c1b2ccb035c3f/common/src/jvmMain/kotlin/com/powersync/ExtractLib.kt#L7-L46) to extract it to a temporary file before passing the path to `addExtension`.
+- **JVM:** Bundle the extension as a resource. Use [`ClassLoader`](https://github.com/powersync-ja/powersync-kotlin/blob/main/common/src/jvmMain/kotlin/com/powersync/ExtractLib.kt) to extract it to a temporary file before passing the path to `addExtension`.
 - **Android:** Build with the [Android NDK](https://developer.android.com/ndk) and pass the library name directly to `addExtension` (`System.loadLibrary` will resolve it).
-- **Kotlin/Native:** Use [cinterops](https://kotlinlang.org/docs/native-c-interop.html) to build the extension as a library. Call its entrypoint via [`sqlite3_auto_extension`](https://github.com/powersync-ja/powersync-kotlin/blob/cd8c6aede9f59f5c19fa2473798c1b2ccb035c3f/common/src/nativeMain/kotlin/com/powersync/ConnectionFactory.native.kt#L8-L14) before opening any PowerSync database.
+- **Kotlin/Native:** Use [cinterops](https://kotlinlang.org/docs/native-c-interop.html) to build the extension as a library. Call its entrypoint via [`sqlite3_auto_extension`](https://github.com/powersync-ja/powersync-kotlin/blob/main/common/src/nativeMain/kotlin/com/powersync/ConnectionFactory.native.kt) before opening any PowerSync database.
 
 ## .NET
 
@@ -138,4 +138,4 @@ For other extensions:
 1. Write Swift Package Manager definitions to build and link the extension with your app.
 2. Depend on [PowerSync CSQLite](https://github.com/powersync-ja/CSQLite).
 3. Add a [module shim](https://github.com/powersync-ja/powersync-swift/tree/main/Sources/PowerSyncCoreShim) target to expose the extension from Swift.
-4. Import that target and CSQLite, then [load the extension statically](https://github.com/powersync-ja/powersync-swift/blob/ad9cf3d8c65dcbf059c4e5430dd35f3706ad5303/Sources/PowerSync/Implementation/sqlite3/registerPowerSyncCoreExtension.swift#L1-L17) before opening a PowerSync database.
+4. Import that target and CSQLite, then [load the extension statically](https://github.com/powersync-ja/powersync-swift/blob/main/Sources/PowerSync/Implementation/sqlite3/registerPowerSyncCoreExtension.swift) before opening a PowerSync database.

--- a/skills/powersync/references/supabase-auth.md
+++ b/skills/powersync/references/supabase-auth.md
@@ -113,7 +113,7 @@ PowerSync automatically sets:
 ```yaml
 client_auth:
   supabase: true
-  supabase_jwt_secret: !env SUPABASE_JWT_SECRET
+  supabase_jwt_secret: !env PS_SUPABASE_JWT_SECRET
 ```
 
 Get the secret from Supabase → Project Settings → JWT. Use `!env` to avoid hardcoding secrets.
@@ -156,11 +156,14 @@ Key details:
 replication:
   connections:
     - type: postgresql
-      uri: postgresql://postgres:postgres@host.docker.internal:54322/postgres
+      uri: postgresql://postgres@host.docker.internal:54322/postgres
+      password: !env PS_SUPABASE_DB_PASSWORD
       sslmode: disable
 ```
 
 Without this you will see: `Replication error postgres does not support ssl`.
+
+Local Supabase database credentials are printed by `supabase status`. Supply the password to the PowerSync service container via the `PS_SUPABASE_DB_PASSWORD` environment variable. The service only substitutes `!env` variables whose names start with `PS_`.
 
 You can verify your local Supabase is using ES256 by checking:
 ```bash

--- a/skills/powersync/references/supabase-auth.md
+++ b/skills/powersync/references/supabase-auth.md
@@ -191,7 +191,7 @@ client_auth:
 - If anonymous access is acceptable, use the anonymous sign-in pattern below.
 - If anonymous auth is disabled on your Supabase project, there is no silent fallback — the agent must gate `db.connect()` behind an explicit auth flow.
 
-`fetchCredentials()` in your backend connector should return the Supabase session JWT. The examples below use the JS Supabase client; equivalent patterns exist for [Dart](https://github.com/powersync-ja/powersync.dart/blob/9ef224175c8969f5602c140bcec6dd8296c31260/demos/supabase-todolist/lib/powersync.dart#L38) and [Kotlin](https://github.com/powersync-ja/powersync-kotlin/blob/main/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt).
+`fetchCredentials()` in your backend connector should return the Supabase session JWT. The examples below use the JS Supabase client; equivalent patterns exist for [Dart](https://github.com/powersync-ja/powersync.dart/blob/main/demos/supabase-todolist/lib/powersync.dart) and [Kotlin](https://github.com/powersync-ja/powersync-kotlin/blob/main/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt).
 
 ### Standard Supabase Auth (JS/TS)
 


### PR DESCRIPTION
The Snyk security audit flags the skills as high risk on skills.sh. The main culprits are:
1. Placeholder credentials in certain files not actual secrets along 
2. PowerSync instance IDs that appear valid. 

This PR fixes the suspected areas that cause the failure and add a check in the validation script to catch potential secrets or URLs as part of the CI process, before allowing merges. There's also updated agent and README instructions for how snyk [agent-scan](https://github.com/snyk/agent-scan) should be used as part of the development process.

AI Disclosure:
Claude Fable was used to do research on why the failure happened and we ran checks using snyk agent-scan to verify the skills. Claude also implemented the fixes discovered under my guidance. 