### PR TITLE
fix: fix dashboard org URL path in terraform reference (powersync-docs #588)

### DIFF
--- a/skills/powersync/references/terraform.md
+++ b/skills/powersync/references/terraform.md
@@ -54,7 +54,7 @@ Organizations are not Terraform-managed resources — they exist when you sign u
 
 ```hcl
 data "powersync_organization" "main" {
-  id = "<org-id>"   # hex segment from the dashboard URL: /orgs/<id>/
+  id = "<org-id>"   # hex segment from the dashboard URL: /org/<id>/
 }
 ```
 


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/588

### What changed in docs

The Terraform guide's "Find Your Organization ID" section corrected the dashboard URL pattern for locating an org ID. The path is `/org/<id>/`, not `/orgs/<id>/`.

### Skill updates in this PR

- `skills/powersync/references/terraform.md`: Updated the comment on the `powersync_organization` data source block to use `/org/<id>/` instead of the incorrect `/orgs/<id>/`.

### Notes for reviewer

The change is a one-character fix in a code comment. No logic, no API surface, no behavior — just a factual correction to the URL example an agent would cite when directing someone to find their org ID in the dashboard.

The snyk-agent-scan demo endpoint returned 403 (network restriction in this environment). The `node scripts/validate.mjs` check passed cleanly. The edit itself introduces no credentials or secret-looking strings, so the snyk result is expected to be clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015pRHQRVhqACBNreorx9wFp)_