### PR TITLE
docs: clarify conflict resolution is backend-owned (powersync-docs #583)

### DIFF
--- a/skills/powersync/references/custom-backend.md
+++ b/skills/powersync/references/custom-backend.md
@@ -172,6 +172,13 @@ The client's `uploadData()` sends pending writes to your backend API. Your backe
 2. Apply them to the database **synchronously** (do not queue for later processing).
 3. Return 2xx — even for validation errors.
 
+### Conflict resolution is backend-owned
+
+If the operator asks how PowerSync resolves write conflicts, do not describe a built-in default. PowerSync is unopinionated: the upload queue is an ordered log of client mutations that must be drained sequentially against endpoints the developer implements, and the app backend decides how those mutations are applied to the source database. PowerSync then replicates the resulting state back to clients. This is server-authoritative reconciliation.
+
+- If the backend applies incoming column values directly (the simple `INSERT ... ON CONFLICT DO UPDATE` and bare `UPDATE ... SET` pattern shown below), the observed system behavior is per-field last-write-wins (LWW), because `PATCH` operations carry only changed columns.
+- If the operator needs anything richer (merge rules, per-field precedence, CRDTs, reject-on-conflict), that logic lives in the backend upload handler, not in PowerSync. See [Handling Update Conflicts](https://docs.powersync.com/handling-writes/handling-update-conflicts.md) and [Custom Conflict Resolution](https://docs.powersync.com/handling-writes/custom-conflict-resolution.md).
+
 ### Request/Response Contract
 
 | Scenario | HTTP Status | Effect on Upload Queue |


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/583

### What changed in docs

The docs now say PowerSync is unopinionated about conflict resolution rather than framing last-write-wins as a built-in default. The developer's backend controls how client mutations are applied to the source database, and per-field LWW is what a naive backend produces, not a system default.

### Skill updates in this PR

- `skills/powersync/references/custom-backend.md`: Adds a "Conflict resolution is backend-owned" subsection under "Backend API for uploadData" so agents stop describing PowerSync as having a built-in LWW default, and route operators to the Handling Update Conflicts and Custom Conflict Resolution docs when richer merge rules are needed.

### Notes for reviewer

No other skill files referenced conflict resolution or a "default behavior", so the edit is confined to `custom-backend.md`. The Snyk agent-scan check required by CLAUDE.md could not run in this sandbox: the proxy denies the `labs.snyk.io` demo endpoint and no `SNYK_TOKEN` is configured. The diff is prose-only and avoids the usual false-positive triggers (no `user:password@`, no long hex strings, no literal credentials, no harvesting wording), and `node scripts/validate.mjs` passes.

Reviewer request or assignee could not be attached automatically if the user is not a collaborator. If that happens, please assign `bean1352` manually.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USzUFUv2AZ41c38CHeKMbN)_