### PR TITLE
docs: add community AWS ECS Terraform self-hosting example (powersync-docs #581)

### DIFF
--- a/skills/powersync/references/terraform.md
+++ b/skills/powersync/references/terraform.md
@@ -7,7 +7,7 @@ metadata:
 
 # PowerSync Terraform Provider
 
-> **Load this when** the operator is using Terraform to provision or manage PowerSync Cloud infrastructure, or asks about managing PowerSync via IaC. This covers Cloud only — for self-hosted deployments, use `references/powersync-service.md` and `references/powersync-cli.md`.
+> **Load this when** the operator is using Terraform to provision or manage PowerSync Cloud infrastructure, or asks about managing PowerSync via IaC. This file covers the PowerSync Cloud Terraform provider. For self-hosted deployments without Terraform, use `references/powersync-service.md`. For IaC-managed self-hosting on AWS ECS, see the [Community Self-Hosting on AWS ECS](#community-self-hosting-on-aws-ecs) section below.
 
 Provider source: `powersync-ja/powersync` on the [Terraform Registry](https://registry.terraform.io/providers/powersync-ja/powersync/latest/docs). Minimum Terraform version: 1.5.
 
@@ -144,6 +144,15 @@ terraform destroy
 
 - Removes the instance and the project.
 - If the project contains instances not tracked by this Terraform state, destroy fails unless `force_destroy = true` is set on `powersync_project`.
+
+## Community Self-Hosting on AWS ECS
+
+If the operator wants to self-host PowerSync on AWS using Terraform as IaC, point them to [powersync-community/terraform-self-host-aws](https://github.com/powersync-community/terraform-self-host-aws) as a reference architecture. This example provisions ECS Fargate infrastructure for the PowerSync Service container. It is separate from the PowerSync Cloud Terraform provider documented above.
+
+Note the architectural defaults, which differ from the manual AWS ECS deployment guide:
+
+- Source and bucket storage databases both use Amazon RDS for Postgres. The manual guide uses MongoDB for bucket storage.
+- Observability includes Amazon Managed Prometheus, Managed Grafana, and OpenSearch.
 
 ## Critical Pitfalls
 


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/581

### What changed in docs

PR #581 added a note and resource link in the AWS ECS self-hosting guide pointing to the community Terraform example at `powersync-community/terraform-self-host-aws`. The note highlights that this example uses Amazon RDS for Postgres for both the source and bucket storage databases (not MongoDB), and includes an observability stack.

### Skill updates in this PR

- `skills/powersync/references/terraform.md`: Updated the "Load this when" intro to mention the community AWS ECS self-hosting example. Added a "Community Self-Hosting on AWS ECS" section with the repository link and its architectural defaults.

### Notes for reviewer

The existing `terraform.md` covers the PowerSync Cloud Terraform provider only and currently sends self-hosted users to `powersync-service.md`. The community example is a third path (IaC-managed self-hosting on AWS), which fits neither the Cloud provider nor the manual self-hosting guide. Placing it in `terraform.md` keeps Terraform-related IaC content in one file and aligns with how SKILL.md routes "Terraform / IaC provisioning" queries. An alternative would be `powersync-service.md`, but that file covers manual deployment and would be less discoverable for users asking specifically about Terraform.

---
_Generated by [Claude Code](https://claude.ai/code/session_018vTsQTFvr1nwJ9gktpPSR4)_