### PR TITLE
Sync from docs: PSYNC_S2305 covers two bucket limits, add self-hosted config (powersync-docs #587)

### DIFF
--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -190,6 +190,7 @@ Key codes to recognize at runtime:
 | `PSYNC_S1005` | Storage version not supported | Caused by a service downgrade; upgrade the PowerSync Service to match the stored version |
 | `PSYNC_S1146` | Replication slot invalidated (`wal_status = 'lost'`) | Use the recovery steps in [Replication Lag Debugging (Postgres)](#replication-lag-debugging-postgres) |
 | `PSYNC_S1601` | MSSQL: CDC capture instance dropped during polling | Re-enable CDC for the affected table; replication resumes automatically once CDC is active |
+| `PSYNC_S2305` | Too many buckets or too many parameter query results | Read the error message: `Too many buckets` means reduce unique bucket count; `Too many parameter query results` means reduce parameter lookup rows. See [Reducing Bucket Count](https://docs.powersync.com/sync/advanced/reducing-bucket-count). |
 
 See [Error Codes Reference](https://docs.powersync.com/debugging/error-codes.md#error-codes-reference) for more information.
 
@@ -242,7 +243,7 @@ Both events share the same `rid`; to match a started/complete pair for a single 
 - **Large initial sync** — sync rules with a large dataset will slow the first sync after connecting. Inspect bucket sizes with the [Sync Diagnostics Client](https://diagnostics-app.powersync.com/).
 - **Upload queue blocking downloads** — by default, uploads are processed before downloads. Buckets and streams at [priority 0](https://docs.powersync.com/sync/advanced/prioritized-sync) are not blocked by uploads but carry trade-offs around sync consistency.
 - **Replication lag on the source database** — high write volume, long-running transactions, bulk updates, or backfills can cause replication to fall behind. See Stage 1 above.
-- **Too many buckets per user** — incremental sync overhead scales roughly linearly with bucket count per user.
+- **Too many buckets or parameter results per user**: two per-user limits apply, both defaulting to 1,000. Exceeding either fails sync with `PSYNC_S2305`. High bucket counts also increase incremental sync overhead roughly linearly. See [Reducing Bucket Count](https://docs.powersync.com/sync/advanced/reducing-bucket-count).
 
 # Replication Lag Debugging (Postgres)
 

--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -240,7 +240,20 @@ This is required by PowerSync and can be configured in two different ways. This 
 
 There are various options when configuring client authentication on a PowerSync Service instance, see [Client Authentication](https://docs.powersync.com/configuration/powersync-service/self-hosted-instances.md#client-authentication) for more information on the options. The options include: JWKS URI, inline JWKs, Supabase Auth, Shared Secrets. Prefer asymmetric keys (RS256, EdDSA, ECDSA) over shared secrets (HS256).
 
-**Important:** There is no `dev: true` auth type in the `client_auth` config schema. It does not exist. For development tokens on self-hosted, configure a real signing key first, then use `powersync generate token`. On PowerSync Cloud, users need to enable development tokens via the dashboard in the Client Auth section of the instance. 
+**Important:** There is no `dev: true` auth type in the `client_auth` config schema. It does not exist. For development tokens on self-hosted, configure a real signing key first, then use `powersync generate token`. On PowerSync Cloud, users need to enable development tokens via the dashboard in the Client Auth section of the instance.
+
+### Per-User Sync Limits
+
+By default, each user connection is limited to 1,000 unique buckets and 1,000 parameter query results. Exceeding either limit fails sync with `PSYNC_S2305`. For self-hosted deployments, raise the limits by adding `api.parameters` to `service.yaml`:
+
+```yaml
+api:
+  parameters:
+    max_buckets_per_connection: 5000
+    max_parameter_query_results: 5000
+```
+
+Set both values. Raising one without the other leaves the connection capped at the limit you did not change. For PowerSync Cloud, request a limit increase (Team and Enterprise plans only). Before raising either limit, review the reduction strategies in [Reducing Bucket Count](https://docs.powersync.com/sync/advanced/reducing-bucket-count).
 
 
 ## PowerSync Cloud Setup

--- a/skills/powersync/references/sync-config.md
+++ b/skills/powersync/references/sync-config.md
@@ -97,7 +97,7 @@ streams:
       - SELECT * FROM <table_b> WHERE ...
 ```
 
-> **Bucket limit**: Each unique `(stream name + parameter values)` combination creates one internal bucket. The default limit is **1,000 buckets per user**. If a stream with subscription parameters could create many combinations, use `queries:` (multiple queries inside one stream) instead of separate streams — this keeps everything in one bucket.
+> **Bucket limits**: Each unique `(stream name + parameter values)` combination creates one internal bucket. Two per-user limits apply, both defaulting to 1,000: unique bucket count and parameter lookup rows (counted before deduplication, across all streams). If a user exceeds either limit, their sync fails with `PSYNC_S2305`. Read the error message to determine which limit was reached, since the fix differs. To keep bucket count low, use `queries:` (multiple queries in one stream) instead of separate streams. See [Bucket Count](https://docs.powersync.com/sync/streams/bucket-count) for how both limits are calculated.
 
 ## Stream Options
 


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/587

### What changed in docs

Docs PR #587 added two new pages (Bucket Count and Limits, Reducing Bucket Count) and clarified that `PSYNC_S2305` covers two distinct per-user limits, not just one: unique bucket count and parameter query results, both defaulting to 1,000. It also documented new `api.parameters` config keys for self-hosted deployments to raise those limits.

### Skill updates in this PR

- `skills/powersync/references/sync-config.md`: Updated the "Bucket limits" callout in the Structure section to mention both per-user limits (unique bucket count and parameter lookup rows), note that exceeding either raises `PSYNC_S2305`, and link to the new Bucket Count docs page.
- `skills/powersync/references/powersync-debug.md`: Added `PSYNC_S2305` to the key error codes table with guidance to read the error message to distinguish which limit was reached. Updated the Common Causes "Too many buckets" entry to mention both limits and link to the new Reducing Bucket Count page.
- `skills/powersync/references/powersync-service.md`: Added a new "Per-User Sync Limits" subsection under Service Configuration (Self-hosted) documenting the `api.parameters.max_buckets_per_connection` and `api.parameters.max_parameter_query_results` keys in `service.yaml`, with a note to set both and a link to the reduction guide.

### Notes for reviewer

The two limits measure different things and can diverge: a user can fail the parameter query results limit while their unique bucket count is still well under 1,000 (for example, if a CTE returns 1,200 org IDs but those collapse into fewer unique buckets after deduplication). The error message text is the reliable signal for which limit was hit, so the skill edits emphasize reading the message before choosing a fix.

The `PSYNC_S1601` action in `powersync-debug.md` still reflects the old guidance (re-enable CDC, replication resumes automatically). PR #76 (open) updates that row and adds further MSSQL error codes. No conflict between these two PRs: they touch the same table but different rows.

No new skill file was created. The new docs pages (bucket-count, reducing-bucket-count) are reference material for developers; the agent-usable rules fit cleanly into the three existing files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCXCVHmByERZzvc4CCbLM3)_