### PR TITLE
Sync from docs: fix InMemoryVfs casing and shared-memory-pool import path (powersync-docs #594)

### DIFF
--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -312,7 +312,7 @@ Multi-tab behavior: By default the web SDK uses a shared sync worker so all tabs
 |---------------------------|---------------------|---------------------------------------------------------------------------------------------------------|
 | IDBBatchAtomicVFS         | Default             | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#1-idbbatchatomicvfs-default)     |
 | OPFSCoopSyncVFS           | Recommended         | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#2-opfs-based-alternatives)       |
-| InMemoryVFS               | No persistence; fast queries; for development or online-only apps with small datasets | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#3-in-memory-vfs) |
+| InMemoryVfs               | No persistence; fast queries; for development or online-only apps with small datasets | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#3-in-memory-vfs) |
 
 ```ts
 // Recommended — more reliable across browsers including Safari
@@ -340,10 +340,10 @@ Use `InMemoryWriteAheadLogPool` only when all of the following hold:
 
 If any condition does not hold, use `OPFSCoopSyncVFS` or the default `IDBBatchAtomicVFS` instead.
 
-Not bundled with `@powersync/web` — import from `@powersync/web/in-memory-wal-experiment` to avoid bundle size impact on apps that do not use it:
+The pool is in a separate package entry point so apps that don't use it don't include it in their main bundle. Import from `@powersync/web/extra/shared-memory-pool`:
 
 ```ts
-import { InMemoryWriteAheadLogPool } from '@powersync/web/in-memory-wal-experiment';
+import { InMemoryWriteAheadLogPool } from '@powersync/web/extra/shared-memory-pool';
 import { PowerSyncDatabase } from '@powersync/web';
 
 const db = new PowerSyncDatabase({


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/594

### What changed in docs

PR #594 corrected two API details in the `@powersync/web` in-memory storage documentation: the `WASQLiteVFS.InMemoryVFS` enum value was renamed to `WASQLiteVFS.InMemoryVfs` (case fix), and the `InMemoryWriteAheadLogPool` import path moved from `@powersync/web/in-memory-wal-experiment` to `@powersync/web/extra/shared-memory-pool`.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-js.md`: corrected `InMemoryVFS` to `InMemoryVfs` in the VFS Options table, and updated the `InMemoryWriteAheadLogPool` import path and its surrounding prose to match the new entry point `@powersync/web/extra/shared-memory-pool`.

### Notes for reviewer

The snyk-agent-scan could not run in this environment (proxy blocks the demo endpoint). The changes are limited to fixing an enum casing and a package path string, neither of which matches the credential or secret patterns the scanner flags.

The docs PR also added a broader "VFS / Option Compatibility Matrix" that includes `InMemoryWriteAheadLogPool`. That table is not mirrored verbatim in the skill file, which covers the pool separately under its own heading. No change was made to that structure, keeping the diff minimal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgHW2uT55Vts5GykcEFgGv)_