### PR TITLE
docs: disconnect/disconnectAndClear nuance and connect once-per-session rule (powersync-docs #602)

### DIFF
--- a/skills/powersync/SKILL.md
+++ b/skills/powersync/SKILL.md
@@ -80,6 +80,7 @@ Always load `references/sdks/powersync-js.md` for any JS/TS project, then load t
 - Never define the `id` column in a PowerSync table schema; it is created automatically.
 - Use `column.integer` for booleans and `column.text` for ISO date strings.
 - `connect()` is fire-and-forget. Use `waitForFirstSync()` if you need readiness.
+- Call `.connect()` once per session. Do not call it again on window focus events, token refreshes, or network changes; redundant calls open additional sync connections.
 - `transaction.complete()` is mandatory or the upload queue stalls permanently.
-- `disconnectAndClear()` is required on logout or user switch when local data must be wiped.
+- On user sign-out, use `disconnectAndClear()` when another user may access the device or security requires wiping local data. If the same user will return to their own device and retaining local data is safe, use `disconnect()` instead. The client resumes from its saved sync position rather than re-downloading everything. Never retain one user's data for a different user.
 - A 4xx response from `uploadData` blocks the upload queue permanently; return 2xx for validation errors.

--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -172,8 +172,8 @@ What it identifies: Whether stale data from a previous user is polluting the loc
 Why: `disconnect()` closes the sync connection but keeps all local data. If you call `disconnect()` on logout and then `connect()` with a new user, the new user's UI will initially display the old user's data until sync completes. `disconnectAndClear()` wipes the local database first, so the new user starts from a clean state.
 
 When to use each:
-- `disconnect()` — temporary offline, token refresh, app backgrounding. Safe to reconnect as the same user.
-- `disconnectAndClear()` — user logout, user account switch. Required to prevent data leakage between users.
+- `disconnect()` — temporary offline, token refresh, app backgrounding, or a same-user sign-out where retaining local data is safe. The client resumes from its saved sync position on the next `.connect()`.
+- `disconnectAndClear()` — user account switch, or any sign-out where another user can access the device or security requires wiping local data. Never retain one user's local data for a different user.
 
 ## PSYNC Error Codes
 


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/602

### What changed in docs

PR #602 added a new "Reducing Usage" page (`resources/usage-and-billing/reducing-usage.mdx`) covering data synced and data hosted optimization strategies, and extensively reworked the usage FAQ with more precise guidance on `disconnect()` vs `disconnectAndClear()`, the single-connect-per-session pattern, and causes of high sync operation counts.

### Skill updates in this PR

- `skills/powersync/SKILL.md`: Split the `disconnectAndClear()` Key Rule into a conditional rule covering both cases. Added a new Key Rule that `.connect()` must be called once per session, not on focus events or token refreshes.
- `skills/powersync/references/powersync-debug.md`: Updated the "when to use each" list in the `disconnectAndClear()` section to include same-user sign-out as a valid `disconnect()` case, matching the nuance introduced in the new docs page.

### Notes for reviewer

**`disconnect()` vs `disconnectAndClear()` on sign-out:** The new docs clarify that `disconnectAndClear()` is not always required on sign-out. If the same user will return to their own device and security permits retaining local data, `disconnect()` is preferable because the client resumes from its saved sync position instead of re-downloading everything. The existing debug file implied `disconnectAndClear()` for any logout, which contradicted the new guidance. Both files now distinguish user-account switches (always use `disconnectAndClear()`) from same-user sign-outs (use `disconnect()` when safe).

**`.connect()` once per session:** The docs FAQ added guidance that opening one `PowerSyncDatabase` and calling `.connect()` once, rather than reconnecting on window focus or token refresh, prevents unnecessary concurrent client counts and reconnect overhead. This pattern was not previously documented in the Key Rules.

**Items intentionally left untouched:** The new docs page also covers compacting, defragmenting, bucket fan-out, large column patterns, `auto_subscribe` behavior, and no-op update footguns. The compacting/defragmenting and bucket fan-out topics already appear in `powersync-debug.md` and `powersync-service.md`. The `auto_subscribe` behavior is covered in `sync-config.md`. No-op updates are a new addition to the docs but are operationally focused (a DBA concern rather than a code-generation concern); adding them to the debug reference may be worth considering in a follow-up.

**Snyk scan:** The `snyk-agent-scan` demo endpoint returned 403 (proxy blocked in the sandbox). The `node scripts/validate.mjs` validation passed. The changed lines contain no connection strings, hex IDs, literal credentials, or credential-harvesting wording, so the scan would be expected to pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYTGVpxne6VEUVEU1aSuGu)_