### PR TITLE
docs: add Compact logs and Migration logs to debug reference (powersync-docs #610)

### DIFF
--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -208,6 +208,8 @@ Put a timestamp in the data. When a row is written or updated in the source data
 
 Check the **Replication Lag** chart in the **Metrics** view of the [PowerSync Dashboard](https://dashboard.powersync.com/). Replicator logs in the **Logs** view surface errors that cause delays at this stage.
 
+On PowerSync Cloud, the **Logs** view also provides two additional log types. **Compact logs** record the daily automatic compacting job and any manually triggered runs. **Migration logs** record the migration job that prepares instance storage during a deploy. If a deploy fails at the migration step, check Migration logs first. If a compacting job is failing or taking longer than expected, check Compact logs.
+
 When the user shares instance logs from the **Logs** view, look for `Flushed` entries. Each entry records one batch written to bucket storage and is the most direct view of replication throughput:
 
 ```


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/610

### What changed in docs

The PowerSync Cloud Dashboard Logs view now includes two new log types: Compact logs (for compacting jobs) and Migration logs (for the storage migration step during a deploy). Documentation was added to the monitoring-and-alerting page, with a cross-reference added from the compacting-buckets page.

### Skill updates in this PR

- `skills/powersync/references/powersync-debug.md`: Added a note in the Stage 1 section explaining that PowerSync Cloud provides Compact logs and Migration logs in the Logs view, with guidance on when to check each.

### Notes for reviewer

The new log types are PowerSync Cloud only; self-hosted does not expose them. The edit is placed in Stage 1 of the Diagnosing Sync Latency section, immediately after the existing mention of Replicator logs, which is where the Logs view is first discussed in detail. No other skill files reference instance log types, so no other files need updating.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SK9UNwFXZMjTX2LDZt5nbf)_