### PR TITLE
Fix frozen plugin installs and expand skill trigger surface (v1.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,18 +7,19 @@
   },
   "metadata": {
     "description": "Add PowerSync Skills to your Claude Code agent",
-    "version": "1.0.0"
+    "version": "1.3.0"
   },
   "plugins": [
     {
       "name": "powersync-skills",
-      "description": "Agent skills that help developers build applications with PowerSync",
+      "description": "Agent skills that help developers build and maintain applications with PowerSync",
       "source": "./",
       "skills": ["./skills/powersync"],
-      "version": "1.0.0",
+      "version": "1.3.0",
       "author": {
         "name": "PowerSync"
       },
+      "homepage": "https://github.com/powersync-ja/agent-skills",
       "keywords": [
         "powersync",
         "offline-first",
@@ -33,7 +34,26 @@
         "typescript"
       ],
       "category": "coding",
-      "license": "MIT"
+      "license": "MIT",
+      "relevance": {
+        "topic": "PowerSync",
+        "signals": {
+          "cli": ["powersync"],
+          "filesRead": [
+            "**/sync-config.yaml",
+            "**/sync-rules.yaml",
+            "**/powersync/service.yaml",
+            "**/powersync/cli.yaml"
+          ],
+          "manifestDeps": [
+            { "file": "[/\\\\]package\\.json$", "pattern": "\"@powersync/" },
+            { "file": "[/\\\\]package\\.json$", "pattern": "\"@journeyapps/wa-sqlite\"" },
+            { "file": "[/\\\\]pubspec\\.yaml$", "pattern": "powersync" },
+            { "file": "[/\\\\]build\\.gradle(\\.kts)?$", "pattern": "com\\.powersync" },
+            { "file": "[/\\\\]Package\\.swift$", "pattern": "powersync" }
+          ]
+        }
+      }
     }
   ]
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,3 +21,6 @@ jobs:
           path: ./skills/powersync
           validate-references: true
           fail-on-warning: true
+          # when_to_use is a Claude Code extension, not part of the agentskills.io
+          # spec, so the action's unknown-field warning must not fail the build.
+          ignore-rules: unknown-field

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,24 @@ Tags are used by skill routing systems for auto-activation. Use terms developers
 
 If you add an example that touches these patterns, make sure it reflects these rules.
 
+## Releases and versioning
+
+The skill has a single version declared in three places that must always match:
+
+1. `skills/powersync/SKILL.md` frontmatter `metadata.version`
+2. `.claude-plugin/marketplace.json` plugin entry `version`
+3. `.claude-plugin/marketplace.json` marketplace `metadata.version`
+
+`node scripts/validate.mjs` fails when they differ, and CI enforces it.
+
+Why this matters: Claude Code re-downloads an installed plugin only when the marketplace plugin `version` string changes. Content merged without a version bump never reaches existing plugin installs.
+
+Policy:
+
+- Every PR that changes anything under `skills/powersync/` or the skill's trigger metadata bumps the version in all three places.
+- Patch (`x.y.Z`) for fixes and small content updates. Minor (`x.Y.0`) for new reference files, new SDK coverage, or description/trigger changes. Major (`X.0.0`) for restructures that change how agents route through the skill.
+- After merging, a maintainer tags the release from `main`: `git tag v<version> && git push origin v<version>`.
+
 ## Submitting a Pull Request
 
 1. Fork the repo and create a branch from `main`.
@@ -112,6 +130,7 @@ If you add an example that touches these patterns, make sure it reflects these r
 - What was wrong or missing?
 - Was any content removed, and if so, why?
 - If a new reference file was added, which entry point files were updated to route to it?
+- Was the version bumped in SKILL.md and marketplace.json?
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PowerSync Agent Skills
 
+[![skills.sh installs](https://skills.sh/b/powersync-ja/agent-skills)](https://skills.sh/powersync-ja/agent-skills)
+
 Agent skills that help developers build applications with [PowerSync](https://powersync.com).
 
 ![PowerSync Agent Skills](assets/sync-dino.png)
@@ -14,16 +16,41 @@ PowerSync skills follow the [Agent Skills](https://agentskills.io/) specificatio
 
 ## Installation
 
-### Skills.sh
+### skills.sh (Cursor, Codex, Copilot, Windsurf, and most other agents)
+
 ```
 npx skills add powersync-ja/agent-skills
 ```
 
-### Claude Code
+The installer detects your agent. To target a specific agent:
+
+```
+npx skills add powersync-ja/agent-skills --agent cursor
+npx skills add powersync-ja/agent-skills --agent codex
+npx skills add powersync-ja/agent-skills --agent github-copilot
+npx skills add powersync-ja/agent-skills --agent claude-code
+```
+
+### Claude Code (plugin)
+
 ```
 /plugin marketplace add powersync-ja/agent-skills
-/plugin install powersync-skills
+/plugin install powersync-skills@powersync
 ```
+
+### Gemini CLI
+
+```
+gemini skills install https://github.com/powersync-ja/agent-skills.git --path skills/powersync
+```
+
+## Updating
+
+Installed skills do not update themselves. To get the latest release:
+
+- skills.sh installs: `npx skills update`
+- Claude Code plugin: `/plugin marketplace update powersync`, then `/plugin update powersync-skills@powersync`
+- Gemini CLI: `gemini skills uninstall powersync`, then reinstall
 
 ## Usage
 

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -46,6 +46,15 @@ function parseFrontmatter(content) {
   return fm;
 }
 
+// parseFrontmatter only captures unindented keys, so the nested metadata.version
+// needs its own lookup. The only indented `version:` line lives under `metadata:`.
+function skillMetadataVersion(content) {
+  const fmBlock = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmBlock) return null;
+  const m = fmBlock[1].match(/^[ \t]+version:[ \t]*["']?([^"'\n]+?)["']?[ \t]*$/m);
+  return m ? m[1].trim() : null;
+}
+
 function validateSkillMd(skillDir, skillName) {
   console.log(`\n[SKILL.md] ${skillName}`);
   const skillMdPath = join(skillDir, 'SKILL.md');
@@ -81,6 +90,17 @@ function validateSkillMd(skillDir, skillName) {
     if (fm.description.length > 1024) error(`description exceeds 1024 characters (${fm.description.length})`);
     if (fm.description.length < 50) warn(`description is short (${fm.description.length} chars) — consider adding more detail`);
     pass('description present');
+  }
+
+  // when_to_use (Claude Code extension): the skill listing shows description +
+  // when_to_use combined, capped at 1536 characters.
+  if (fm.when_to_use) {
+    const combined = (fm.description ? fm.description.length : 0) + fm.when_to_use.length;
+    if (combined > 1536) {
+      error(`description + when_to_use exceed 1536 characters (${combined}); Claude Code truncates the listing`);
+    } else {
+      pass(`description + when_to_use within listing budget (${combined}/1536)`);
+    }
   }
 
   // body length
@@ -266,6 +286,41 @@ function validateMarketplace() {
         } else {
           pass(`plugin "${plugin.name}" → ${skillPath}`);
         }
+      }
+
+      // Version parity: Claude Code only re-downloads an installed plugin when
+      // this version string changes, so it must move with the skill content.
+      for (const skillPath of plugin.skills) {
+        const skillMdPath = join(resolve(ROOT, skillPath), 'SKILL.md');
+        if (!existsSync(skillMdPath)) continue;
+        const skillVersion = skillMetadataVersion(readFileSync(skillMdPath, 'utf-8'));
+        if (!plugin.version) {
+          error(`Plugin "${plugin.name}" has no version; installs will never update`);
+        } else if (skillVersion && plugin.version !== skillVersion) {
+          error(`Plugin "${plugin.name}" version ${plugin.version} != ${skillPath}/SKILL.md metadata.version ${skillVersion}; bump both together`);
+        } else if (skillVersion) {
+          pass(`plugin "${plugin.name}" version matches SKILL.md metadata.version (${plugin.version})`);
+        } else {
+          warn(`${skillPath}/SKILL.md has no metadata.version to compare against plugin "${plugin.name}"`);
+        }
+      }
+    }
+    if (manifest.metadata?.version && plugin.version && manifest.metadata.version !== plugin.version) {
+      error(`marketplace metadata.version ${manifest.metadata.version} != plugin "${plugin.name}" version ${plugin.version}`);
+    }
+
+    // relevance block shape (Claude Code suggestion signals)
+    if (plugin.relevance !== undefined) {
+      const sig = plugin.relevance?.signals;
+      if (typeof plugin.relevance !== 'object' || !sig || Object.keys(sig).length === 0) {
+        error(`Plugin "${plugin.name}" relevance must be an object with a non-empty signals object`);
+      } else {
+        for (const dep of sig.manifestDeps ?? []) {
+          if (typeof dep?.file !== 'string' || typeof dep?.pattern !== 'string') {
+            error(`Plugin "${plugin.name}" relevance.signals.manifestDeps entries need string "file" and "pattern"`);
+          }
+        }
+        pass(`plugin "${plugin.name}" relevance signals: ${Object.keys(sig).join(', ')}`);
       }
     }
   }

--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -1,6 +1,6 @@
 # PowerSync Skills
 
-Use this skill to onboard a project onto PowerSync without trial-and-error. Treat this as a guided workflow first and a reference library second.
+Use this skill to onboard a project onto PowerSync and to keep it healthy afterwards, without trial-and-error. Treat this as a guided workflow first and a reference library second.
 
 ## Terminology (read first)
 
@@ -85,6 +85,11 @@ When the task is to add PowerSync to an app, follow this sequence:
    - Self-hosted: `powersync init self-hosted` → `powersync docker configure` → `powersync docker start`
    - Source DB steps the agent cannot run (e.g. Supabase publication SQL): present the exact SQL, ask the operator to confirm done.
 8. Only after backend readiness is confirmed, implement app-side PowerSync integration.
+9. **Offer to leave a pointer in the project's agent context file.** After onboarding succeeds (Cloud Readiness Gate passed and the app integration works), future agent sessions should load this skill even when a prompt never mentions sync. Propose this to the operator and, on approval:
+   - If the project root has `AGENTS.md`, append the pointer line there. Otherwise, if it has `CLAUDE.md`, append it there. If neither exists, create `AGENTS.md` containing only the pointer line.
+   - Pointer line, verbatim: `This project uses PowerSync. Load the powersync skill before any data, schema, or sync work.`
+   - Skip this step (and say so) if the file already mentions PowerSync (search case-insensitively); never add a duplicate.
+   - Append the line at the end of the file as its own paragraph. Do not rewrite, reorder, or reformat existing content.
 
 UI stuck on `Syncing...`? Default diagnosis is incomplete backend setup, not a frontend bug. Do not start client-side debugging while the service is unconfigured.
 

--- a/skills/powersync/SKILL.md
+++ b/skills/powersync/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: powersync
-description: Guided onboarding and best practices for building applications with PowerSync — Cloud and self-hosted setup, sync configuration, client SDK usage, backend integration (Supabase, custom Postgres, MongoDB, MySQL, MSSQL), and debugging. Use this skill whenever the user mentions PowerSync, offline-first sync, local-first architecture, sync rules, sync streams, uploadData, fetchCredentials, real-time data replication, Electric Cloud migration, Electric Shapes, or wants to add offline-capable sync to a mobile or web app — even if they don't explicitly name PowerSync.
+description: "Best practices for building and maintaining applications with PowerSync: Cloud and self-hosted setup, sync configuration, client SDK usage, backend integration (Supabase, custom Postgres, MongoDB, MySQL, MSSQL), schema changes, watch and reactive queries (useQuery), attachments, the upload queue, and debugging. Use this skill whenever the user mentions PowerSync, a @powersync/* package (@powersync/web, @powersync/react-native, @powersync/node), the powersync Flutter/Dart package, wa-sqlite, offline-first sync, local-first architecture, sync rules, sync streams, uploadData, fetchCredentials, disconnectAndClear, logout or user switching in a synced app, real-time data replication, Electric Cloud migration, Electric Shapes, an app stuck on Syncing, data not syncing, or wants to add offline-capable sync to a mobile or web app, even if they do not explicitly name PowerSync."
+when_to_use: "Load before any data, schema, sync, or auth change in a project that already uses PowerSync, even if the request never mentions sync. Examples: adding tables or columns, watch or useQuery results not updating, rows missing on a device, uploads stuck in the queue, a spinner stuck on Syncing, editing sync-config.yaml or service.yaml, running powersync CLI commands, migrating legacy sync configuration to Sync Streams, or implementing logout and account switching with disconnectAndClear."
 license: MIT
 compatibility: Works with any skills-compatible agent. Some references include CLI commands requiring the @powersync/cli package.
 metadata:
   author: powersync
-  version: "1.2.0"
+  version: "1.3.0"
   organization: PowerSync
-  tags: powersync, offline-first, local-first, sync-streams, sqlite, replication, uploadData, fetchCredentials, service-config, sync-config, cloud, cli, debugging, supabase, postgres, mongodb, mysql, electric, electric-migration
+  tags: powersync, offline-first, local-first, sync-streams, sqlite, replication, uploadData, fetchCredentials, service-config, sync-config, cloud, cli, debugging, supabase, postgres, mongodb, mysql, electric, electric-migration, watch-queries, useQuery, attachments, upload-queue, disconnectAndClear, schema, react-native, flutter, node, web, wa-sqlite
 ---
 
 # PowerSync Skills
 
-Use this skill to onboard a project onto PowerSync without trial-and-error. Treat this as a guided workflow first and a reference library second.
+Use this skill to onboard a project onto PowerSync and to keep it healthy afterwards, without trial-and-error. Treat this as a guided workflow first and a reference library second.
 
 **Agents: Read [AGENTS.md](AGENTS.md) before proceeding.** It contains the mandatory compliance rules and onboarding playbook. The Quick Rules below are a reminder, not a substitute. **`powersync login`** is **PowerSync Cloud only** (PAT); self-hosted does not use it.
 


### PR DESCRIPTION
Claude Code only re-downloads an installed plugin when the marketplace plugin version changes. That field sat at 1.0.0 since first release, so every plugin install was frozen at the March first-release content while the skill moved to 1.2.0. This bumps all versions to 1.3.0 and makes the staleness impossible to reintroduce:

- marketplace.json: bump plugin and marketplace versions to 1.3.0, add homepage and relevance signals (powersync CLI, sync config files, @powersync deps in package.json/pubspec.yaml/gradle/Package.swift)
- SKILL.md: rewrite description for the dev loop (watch/reactive queries, schema changes, attachments, upload queue, package names, stuck-on-Syncing) and add when_to_use for Claude Code; bump to 1.3.0
- validate.mjs: fail CI when plugin version, marketplace version, and SKILL.md metadata.version diverge; enforce the 1536-char combined description + when_to_use listing budget; validate relevance shape
- validate.yml: ignore the unknown-field warning so when_to_use (a Claude Code extension) passes the spec validator
- AGENTS.md: onboarding step 9 offers to add a pointer line to the host project's agent context file so the skill loads on prompts that never mention sync
- README: skills.sh badge, per-agent install matrix, update commands
- CONTRIBUTING: version-bump policy and release tagging

## AI Disclosure 
Claude Opus 5 was used to implement the code needed to fix the issues but guided by myself.