### PR TITLE
 [Supabase onboarding] Create a dedicated postgres role

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Add PowerSync Skills to your Claude Code agent",
-    "version": "1.3.0"
+    "version": "1.3.1"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
       "description": "Agent skills that help developers build and maintain applications with PowerSync",
       "source": "./",
       "skills": ["./skills/powersync"],
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "PowerSync"
       },

--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -83,7 +83,7 @@ When the task is to add PowerSync to an app, follow this sequence:
 7. **Create/link the instance and deploy config before app code.** CLI only — do not hand-create config files.
    - Cloud: `powersync init cloud` → edit config → `powersync link cloud --create` → `powersync deploy`
    - Self-hosted: `powersync init self-hosted` → `powersync docker configure` → `powersync docker start`
-   - Source DB steps the agent cannot run (e.g. Supabase publication SQL): present the exact SQL, ask the operator to confirm done.
+   - Source DB steps the agent cannot run (e.g. Supabase `powersync_replication` user + publication SQL): present the exact SQL, ask the operator to confirm done.
 8. Only after backend readiness is confirmed, implement app-side PowerSync integration.
 9. **Offer to leave a pointer in the project's agent context file.** After onboarding succeeds (Cloud Readiness Gate passed and the app integration works), future agent sessions should load this skill even when a prompt never mentions sync. Propose this to the operator and, on approval:
    - If the project root has `AGENTS.md`, append the pointer line there. Otherwise, if it has `CLAUDE.md`, append it there. If neither exists, create `AGENTS.md` containing only the pointer line.
@@ -152,7 +152,7 @@ Do not proceed to app-side code until **all** items below are verified:
 - Sync config is deployed
 - Client auth is configured
 - Instance URL is available for `fetchCredentials()`
-- Source database replication/publication setup is complete
+- Source database replication/publication setup is complete, including the dedicated replication user (`powersync_replication` for Supabase/Postgres — never connect as a superuser)
 - All credentials and URLs are in `.env` (e.g. `POWERSYNC_URL`, `PS_DATABASE_URI`, plus any backend-specific keys)
 
 Missing item? Finish service setup first. Use the CLI to verify and complete. For steps the agent cannot perform (e.g. running SQL in the source DB), present the exact commands and ask the operator to confirm completion before writing app code.

--- a/skills/powersync/SKILL.md
+++ b/skills/powersync/SKILL.md
@@ -6,7 +6,7 @@ license: MIT
 compatibility: Works with any skills-compatible agent. Some references include CLI commands requiring the @powersync/cli package.
 metadata:
   author: powersync
-  version: "1.3.0"
+  version: "1.3.1"
   organization: PowerSync
   tags: powersync, offline-first, local-first, sync-streams, sqlite, replication, uploadData, fetchCredentials, service-config, sync-config, cloud, cli, debugging, supabase, postgres, mongodb, mysql, electric, electric-migration, watch-queries, useQuery, attachments, upload-queue, disconnectAndClear, schema, react-native, flutter, node, web, wa-sqlite
 ---

--- a/skills/powersync/references/onboarding-supabase.md
+++ b/skills/powersync/references/onboarding-supabase.md
@@ -21,7 +21,7 @@ Collect before editing app code:
 - PowerSync instance URL (if instance exists)
 - Instance ID (if using CLI with an existing instance)
 - Project ID (if using CLI to create a new Cloud instance via `powersync link cloud --create`); also Org ID if the PAT covers multiple organizations
-- Supabase Postgres connection string (if source DB connection not yet configured)
+- Supabase Postgres **direct** connection string (if source DB connection not yet configured) — PowerSync connects as the dedicated `powersync_replication` user created in step 3, never as the `postgres` superuser
 - `PS_ADMIN_TOKEN` or willingness to run `powersync login` (Cloud PAT only)
 
 Only ask for the Postgres connection string when you reach the service configuration step.
@@ -38,7 +38,11 @@ Follow this sequence exactly. **Do not skip ahead to app code.**
 
 2. **Keep credentials in `.env`, never hardcoded.** As soon as Supabase project details are available, record `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `PS_DATABASE_URI`, and `POWERSYNC_URL` in `.env`. Both `service.yaml` (via `!env` tags) and app code depend on these values. For how to get `POWERSYNC_URL`, see `references/powersync-cli.md` § "Getting POWERSYNC_URL". New Supabase projects use publishable keys (prefixed `sb_publishable_…`) instead of the legacy anon key — use it as the value for `SUPABASE_ANON_KEY`.
 
-3. **Run the Supabase publication SQL.** The publication must exist before PowerSync connects to the database. See `references/supabase-auth.md` § "Supabase Database Setup" for the exact SQL. Present it to the operator and ask them to confirm.
+3. **Create the PowerSync database user and publication.** Both must exist before PowerSync connects to the database. See `references/supabase-auth.md` § "Supabase Database Setup" for the exact SQL, in this order:
+   1. Create the `powersync_replication` user (`REPLICATION BYPASSRLS LOGIN` + `SELECT` grants). Have the operator generate a secure password; record it in `.env` (e.g. `PS_DATABASE_PASSWORD`).
+   2. Create the `powersync` publication.
+
+   Present the SQL to the operator and ask them to confirm it ran. `PS_DATABASE_URI` must then use `powersync_replication` as the username with Supabase's **direct** connection host (not the pooler).
 
 4. **Scaffold and configure PowerSync.**
    - **New instance (CLI):** `powersync init cloud` → edit config → `powersync link cloud --create --project-id=<id>` → deploy
@@ -64,7 +68,7 @@ Follow this sequence exactly. **Do not skip ahead to app code.**
 Do not proceed to app code until all items are verified:
 
 - [ ] PowerSync instance exists and is running
-- [ ] Source database connection is configured
+- [ ] Source database connection is configured and uses the dedicated `powersync_replication` user (not `postgres`)
 - [ ] Supabase publication exists for synced tables
 - [ ] Sync config is deployed with `config: edition: 3`
 - [ ] Client auth is configured for Supabase

--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -21,7 +21,7 @@ Before asking for console logs or editing app code, verify these in order:
 2. The PowerSync service has a valid source DB connection.
 3. Sync config was deployed and starts with `config: edition: 3`.
 4. Client auth is configured correctly (Supabase auth, custom JWKS, or other provider).
-5. Source database replication/publication/CDC is set up for the synced tables.
+5. Source database replication/publication/CDC is set up for the synced tables, and the replication user can read them (see [Replication User Permission Errors (Postgres)](#replication-user-permission-errors-postgres)).
 
 Only inspect frontend connector code or SDK state after all five checks pass.
 
@@ -244,6 +244,26 @@ Both events share the same `rid`; to match a started/complete pair for a single 
 - **Upload queue blocking downloads** — by default, uploads are processed before downloads. Buckets and streams at [priority 0](https://docs.powersync.com/sync/advanced/prioritized-sync) are not blocked by uploads but carry trade-offs around sync consistency.
 - **Replication lag on the source database** — high write volume, long-running transactions, bulk updates, or backfills can cause replication to fall behind. See Stage 1 above.
 - **Too many buckets or parameter results per user**: two per-user limits apply, both defaulting to 1,000. Exceeding either fails sync with `PSYNC_S2305`. High bucket counts also increase incremental sync overhead roughly linearly. See [Reducing Bucket Count](https://docs.powersync.com/sync/advanced/reducing-bucket-count).
+
+# Replication User Permission Errors (Postgres)
+
+The PowerSync connection uses a dedicated read-only role (`powersync_replication`). Two failure modes are specific to that limited role:
+
+**`permission denied for table <name>` in service replicator logs.** The replication role is missing `SELECT` on a table referenced by the sync config. Common cause: the table was created after initial setup by a role other than the one that ran `ALTER DEFAULT PRIVILEGES`, so the automatic `SELECT` grant did not apply. Also occurs for tables outside the `public` schema (needs `GRANT USAGE ON SCHEMA` too). Fix by running the missing grant as an admin user, e.g.:
+
+```sql
+GRANT SELECT ON public.<table> TO powersync_replication;
+```
+
+Then redeploy or wait for the service to retry the snapshot.
+
+**Rows missing (some or all) with no errors, RLS enabled on source tables.** The replication role lacks `BYPASSRLS`, so the initial snapshot's `SELECT`s are filtered by RLS policies. Verify with `SELECT rolname, rolbypassrls FROM pg_roles WHERE rolname = 'powersync_replication';` and fix with:
+
+```sql
+ALTER ROLE powersync_replication BYPASSRLS;
+```
+
+A resync (redeploy sync config) is required after fixing, since already-snapshotted tables stay filtered.
 
 # Replication Lag Debugging (Postgres)
 

--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -135,6 +135,9 @@ For PowerSync Cloud, the minimal shape depends on your auth provider.
 replication:
   connections:
     - type: postgresql
+      # Username must be the dedicated powersync_replication user, e.g.
+      # postgresql://powersync_replication@db.<project-ref>.supabase.co:5432/postgres
+      # See references/supabase-auth.md § "Supabase Database Setup"
       uri: !env PS_DATABASE_URI
 
 client_auth:
@@ -324,12 +327,16 @@ If the operator's source database version is below the minimum, advise them to u
 
 ### PostgreSQL Quick Start
 
+> **Supabase:** skip this quick start and follow `references/supabase-auth.md` § "Supabase Database Setup" instead — it creates `powersync_replication` with `BYPASSRLS` (Supabase enables row-level security by default) and logical replication is already enabled.
+
 ```sql
 -- 1. Enable logical replication (skip this step for Supabase — it is already enabled)
 ALTER SYSTEM SET wal_level = 'logical';
 -- Restart PostgreSQL after this
 
 -- 2. Create replication user (replace with a generated secure password—do NOT use "secure_password")
+-- Add BYPASSRLS if any replicated table has row-level security enabled,
+-- otherwise the initial snapshot is silently filtered by RLS policies.
 CREATE USER powersync_replication WITH REPLICATION PASSWORD 'YOUR_GENERATED_PASSWORD';
 
 -- 3. Grant read access

--- a/skills/powersync/references/supabase-auth.md
+++ b/skills/powersync/references/supabase-auth.md
@@ -1,8 +1,8 @@
 ---
 name: supabase-auth
-description: Configuring PowerSync with Supabase — database publication setup, JWT signing keys, Cloud dashboard setup, self-hosted service.yaml config, fetchCredentials() implementation, and error codes
+description: Configuring PowerSync with Supabase — database user (powersync_replication) and publication setup, JWT signing keys, Cloud dashboard setup, self-hosted service.yaml config, fetchCredentials() implementation, and error codes
 metadata:
-  tags: supabase, auth, jwt, jwks, client_auth, fetchCredentials, authentication, hs256, rs256, publication, replica-identity
+  tags: supabase, auth, jwt, jwks, client_auth, fetchCredentials, authentication, hs256, rs256, publication, replica-identity, powersync_replication, replication-user, bypassrls
 ---
 
 # PowerSync + Supabase Auth
@@ -21,9 +21,41 @@ PowerSync verifies Supabase JWTs directly when connected to a Supabase-hosted Po
 
 ## Supabase Database Setup
 
-Supabase already has logical replication enabled at the WAL level. You still need to create a publication so PowerSync knows which tables to replicate, and set `REPLICA IDENTITY FULL` on each table so that DELETE operations include the full row (required for PowerSync to sync deletes to clients).
+Supabase already has logical replication enabled at the WAL level. Two things must still exist before PowerSync connects: a dedicated database user for the PowerSync connection, and a publication listing the tables to replicate. Run both in the Supabase SQL Editor **after creating your tables**, in this order.
 
-Run this in the Supabase SQL Editor **after creating your tables**:
+### 1. Create the PowerSync database user
+
+PowerSync connects as a dedicated role, **not** as the `postgres` superuser. Generate a secure password first (e.g. `openssl rand -base64 32` or a password manager), then run:
+
+```sql
+-- Create a role/user with replication privileges for PowerSync
+-- (replace with the generated password — do NOT use a placeholder value)
+CREATE ROLE powersync_replication WITH REPLICATION BYPASSRLS LOGIN PASSWORD 'YOUR_GENERATED_PASSWORD';
+
+-- Read-only access is all PowerSync needs — it never writes to Supabase.
+-- Client writes go through uploadData() → supabase-js as the end user.
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO powersync_replication;
+
+-- Also cover tables created in the future
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO powersync_replication;
+```
+
+Why each attribute matters:
+
+- `REPLICATION` — required to create the logical replication slot.
+- `BYPASSRLS` — Supabase enables row-level security on most tables. Without it, the initial snapshot (plain `SELECT`s) is filtered by RLS policies and rows silently never reach clients.
+- `LOGIN` + `SELECT` only — least privilege. Do not grant write access; nothing in PowerSync needs it.
+
+**Use these credentials for the PowerSync connection:**
+
+- **CLI / self-hosted:** the connection username is `powersync_replication`, e.g. `PS_DATABASE_URI=postgresql://powersync_replication@db.<project-ref>.supabase.co:5432/postgres` in `.env`, with the password supplied separately (`password: secret: !env PS_DATABASE_PASSWORD` for Cloud — see `references/powersync-cli.md` § "Cloud Secrets").
+- **Dashboard:** paste Supabase's connection string, then update the **Username** and **Password** fields to `powersync_replication` and its password.
+- Use Supabase's **Direct connection** string (port 5432), not the transaction pooler — the pooler does not support logical replication. PowerSync includes Supabase's CA certificate, so `sslmode: verify-full` works without extra configuration.
+- `client_auth: supabase: true` auto-detection is unaffected by the role — it reads the project ref from the hostname, not the username.
+
+### 2. Create the publication
+
+Create a publication so PowerSync knows which tables to replicate, and set `REPLICA IDENTITY FULL` on each table so that DELETE operations include the full row (required for PowerSync to sync deletes to clients).
 
 ```sql
 -- Create the PowerSync publication (required)
@@ -36,6 +68,17 @@ When you add a new table that PowerSync should replicate, add it to the publicat
 ```sql
 CREATE PUBLICATION powersync FOR ALL TABLES;
 ```
+
+### Keeping `powersync_replication` grants intact
+
+The limited role can lose read access as the schema evolves. Two cases to watch:
+
+- **Tables created by a different role.** `ALTER DEFAULT PRIVILEGES` only covers tables created by the role that ran it (`postgres` when using the SQL Editor or Supabase CLI migrations). A table created by any other role needs an explicit `GRANT SELECT ON public.<table> TO powersync_replication;`.
+- **Tables outside `public`.** The grants above cover only the `public` schema. For another schema: `GRANT USAGE ON SCHEMA <schema> TO powersync_replication;` plus `GRANT SELECT ON ALL TABLES IN SCHEMA <schema> TO powersync_replication;`.
+
+A missing grant surfaces as `permission denied for table <name>` in the PowerSync service logs when the table is snapshotted (first deploy referencing it, or a resync). Fix by running the missing `GRANT` — see `references/powersync-debug.md`.
+
+**Local Supabase (`supabase start`):** the default `postgres` user is fine for local development — the dedicated role matters for hosted projects. The local examples below intentionally use `postgres`.
 
 ### Data API Grants
 

--- a/skills/powersync/references/terraform.md
+++ b/skills/powersync/references/terraform.md
@@ -90,7 +90,7 @@ resource "powersync_instance" "main" {
     name     = "main"
     hostname = "db.<project-ref>.supabase.co"
     port     = 5432
-    username = "powersync_role"
+    username = "powersync_replication"
     password = var.replication_password
     database = "postgres"
     sslmode  = "verify-full"
@@ -150,4 +150,4 @@ terraform destroy
 - Never inline credentials in HCL or state. Use `TF_VAR_*` environment variables for sensitive Terraform variables.
 - `sync_config_content` must include the `config: edition: 3` wrapper — the same requirement as `sync-config.yaml` for the CLI. Missing this wrapper causes validation/deploy failures.
 - Terraform manages the full instance lifecycle. Do not mix CLI deploys (`powersync deploy`) against the same instance managed by Terraform — the two tools will overwrite each other's changes.
-- For Supabase source databases, the Supabase publication and `powersync_role` still need to be configured separately (Terraform does not manage source-DB-side replication setup). See `references/supabase-auth.md`.
+- For Supabase source databases, the Supabase publication and `powersync_replication` still need to be configured separately (Terraform does not manage source-DB-side replication setup). See `references/supabase-auth.md`.


### PR DESCRIPTION
Resolves https://github.com/powersync-ja/agent-skills/issues/80 - I didn't really read or follow the content of that issue, it was more of a "see something, say something" dump at that time.

This ensures that agents also create a dedicated "powersync_replication" role when following the Supabase onboarding guide. It is highly opiniated about never using the default postgres role.

Since this role has fewer privileges by default than the superuser postgres role, this also includes a section about relevant User Permission Errors.

The role is called "powersync_replication" unlike "powersync_role" in the [docs](https://docs.powersync.com/integrations/supabase/guide#create-a-powersync-database-user) to stay consistent with the name we use for other Postgres database setups in these skills.

🤖 Claude Code implemented the changes and I reviewed them.