### PR TITLE
docs: expand checkpoint request support to JS, Dart, and Kotlin (powersync-docs #595)

### DIFF
--- a/skills/powersync/references/sdks/powersync-dart.md
+++ b/skills/powersync/references/sdks/powersync-dart.md
@@ -2,7 +2,7 @@
 name: powersync-dart
 description: PowerSync Dart SDK — schema, queries, sync lifecycle, backend connectors, Drift ORM, Flutter Web support, and encryption
 metadata:
-  tags: dart, flutter, flutter-web, drift, orm, sqlite, encryption, sqlcipher, sqlite3mc
+  tags: dart, flutter, flutter-web, drift, orm, sqlite, encryption, sqlcipher, sqlite3mc, checkpoint-requests
 ---
 
 # PowerSync Dart SDK
@@ -145,6 +145,88 @@ If statement preparation overhead is visible in profiling, set `preparedStatemen
 
 See [sync-config.md](references/sync-config.md) for how to subscribe to Sync Streams when `auto_subscribe` is not set to `true` in the PowerSync Service config.
 
+## Checkpoint Requests (Alpha)
+
+Checkpoint requests let you confirm that the local database has caught up to a specific server state. Use this when you need to know that server changes are available locally: after a local write to wait for the result to sync back, in a pull-to-refresh flow, or when a user opens a link that refers to data that may not have synced yet.
+
+Requires PowerSync Service v1.24.0+. .NET and Rust SDKs do not yet support checkpoint requests.
+
+To opt in, pass `checkpointMode: .requests()` in `SyncOptions` to `connect()`:
+
+```dart
+await db.connect(
+  connector: connector,
+  options: SyncOptions(checkpointMode: .requests()),
+);
+```
+
+Without this option, calling `requestCheckpoint()` throws an error. Checkpoint IDs are represented as strings in the Dart SDK to match the JavaScript SDK's representation (large int64 values exceed the safe integer range for JavaScript numbers).
+
+### Waiting for the Latest Server Data
+
+```dart
+final checkpoint = await database.requestCheckpoint();
+await checkpoint.waitForSync(
+  abortTrigger: Future.delayed(Duration(seconds: 30)),
+);
+// Local queries now reflect server state from when requestCheckpoint() was called.
+```
+
+`requestCheckpoint()` requires the database to be connected or connecting. If offline, the call suspends until the Service is reachable. Aborting `waitForSync` does not remove the checkpoint. It only limits how long you wait for the checkpoint to apply locally.
+
+### Error Handling
+
+```dart
+try {
+  final checkpoint = await database.requestCheckpoint();
+  await checkpoint.waitForSync(
+    abortTrigger: Future.delayed(Duration(seconds: 30)),
+  );
+} on AbortException {
+  showRefreshMessage('The refresh timed out. Try again.');
+} catch (e) {
+  showRefreshMessage('Could not wait for checkpoint: $e');
+}
+```
+
+### Relationship to Local Writes
+
+When checkpoint requests are enabled, the SDK creates an internal request after each upload queue flush. You do not need to call `requestCheckpoint()` for your own writes. If you create a request while local writes are pending, waiting on it also waits for those writes to upload and their results to sync back:
+
+```dart
+await database.execute(
+  'INSERT INTO tasks (id, description) VALUES (uuid(), ?)',
+  ['Review the project plan'],
+);
+final checkpoint = await database.requestCheckpoint();
+await checkpoint.waitForSync();
+// The pending write has uploaded and its server state has synced locally.
+```
+
+This behavior relies on `uploadData()` returning only after your backend has committed the changes to the source database.
+
+### Async Upload Backends (Team/Enterprise)
+
+If `uploadData()` queues writes for later processing rather than committing them synchronously, mix in `CustomCheckpointRequestConnector` and implement `postCheckpointRequest`. This requires a `checkpoint_requests` event definition in your sync config and is available on [Team and Enterprise](https://www.powersync.com/pricing) plans:
+
+```dart
+final class MyBackendConnector extends PowerSyncBackendConnector
+    with CustomCheckpointRequestConnector {
+  // ... also implement fetchCredentials and uploadData
+
+  @override
+  Future<String> postCheckpointRequest(
+    String clientId,
+    String requestId,
+  ) async {
+    final response = await myBackend.createCheckpointRequest(clientId, requestId);
+    return response.checkpointRequestId;
+  }
+}
+```
+
+See [Checkpoint Requests](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests) for the full setup guide.
+
 ## Query Patterns
 
 See [Using PowerSync: CRUD](https://docs.powersync.com/client-sdks/reference/flutter.md#using-powersync-crud-functions) for the full API reference.
@@ -221,7 +303,7 @@ See [Flutter Web Support](https://docs.powersync.com/client-sdks/frameworks/flut
 Two options are available for encrypting the local SQLite database at rest:
 
 | Option | Platforms |
-|--------|-----------|
+|--------|----------|
 | [SQLite3MultipleCiphers](https://utelle.github.io/SQLite3MultipleCiphers) | Native + web |
 | [SQLCipher Community Edition](https://www.zetetic.net/sqlcipher/) | Native only |
 

--- a/skills/powersync/references/sdks/powersync-js.md
+++ b/skills/powersync/references/sdks/powersync-js.md
@@ -2,7 +2,7 @@
 name: powersync-js
 description: PowerSync JavaScript/TypeScript SDK — schema, backend connector, queries, transactions, sync status, and debugging
 metadata:
-  tags: javascript, typescript, web, sqlite, offline-first
+  tags: javascript, typescript, web, sqlite, offline-first, checkpoint-requests
 ---
 
 > **Load this when** working on any JavaScript or TypeScript project with PowerSync. This is the foundation file — always load it first, then load the applicable framework-specific file alongside it.
@@ -18,6 +18,7 @@ Core patterns and guidance shared across all PowerSync JavaScript/TypeScript tar
 - [Query Patterns](#query-patterns) (useQuery, CompilableQuery, Imperative, Watch)
 - [Writes & Transactions](#writes--transactions)
 - [Sync Status, Priorities & Sync Streams](#sync-status-priorities--sync-streams)
+- [Checkpoint Requests (Alpha)](#checkpoint-requests-alpha)
 - [Debugging](#debugging)
 - [Common Pitfalls](#common-pitfalls)
 
@@ -709,6 +710,77 @@ subscription.unsubscribe();
 - Default streams: server may configure streams as default — these subscribe automatically without a client call
 - TTL eviction: after TTL expires with no active subscriber, the stream's data may be removed from the local DB
 
+## Checkpoint Requests (Alpha)
+
+Checkpoint requests let you confirm that the local database has caught up to a specific server state. Use this when you need to know that server changes are available locally: after a local write to wait for the result to sync back, in a pull-to-refresh flow, or when a user opens a link that refers to data that may not have synced yet.
+
+Requires PowerSync Service v1.24.0+. .NET and Rust SDKs do not yet support checkpoint requests.
+
+To opt in, pass `checkpointMode: 'requests'` to `connect()`:
+
+```ts
+await db.connect(connector, { checkpointMode: 'requests' });
+```
+
+Without this option, calling `requestCheckpoint()` throws an error. Checkpoint IDs are represented as strings in the JS/TS SDK because large int64 values exceed the safe integer range for JavaScript numbers.
+
+### Waiting for the Latest Server Data
+
+```ts
+const checkpoint = await database.requestCheckpoint();
+await checkpoint.waitForSync({ signal: AbortSignal.timeout(30_000) });
+// Local queries now reflect server state from when requestCheckpoint() was called.
+```
+
+`requestCheckpoint()` requires the database to be connected or connecting. If offline, the call suspends until the Service is reachable. Aborting `waitForSync` or reaching a timeout does not remove the checkpoint. It only limits how long you wait for the checkpoint to apply locally.
+
+### Error Handling
+
+```ts
+const signal = AbortSignal.timeout(30_000);
+
+try {
+  const checkpoint = await database.requestCheckpoint();
+  await checkpoint.waitForSync({ signal });
+} catch (e) {
+  if (signal.aborted) {
+    showRefreshMessage('The refresh timed out. Try again.');
+  } else {
+    showRefreshMessage(`Could not wait for checkpoint: ${e}`);
+  }
+}
+```
+
+### Relationship to Local Writes
+
+When checkpoint requests are enabled, the SDK creates an internal request after each upload queue flush. You do not need to call `requestCheckpoint()` for your own writes. If you create a request while local writes are pending, waiting on it also waits for those writes to upload and their results to sync back:
+
+```ts
+await database.execute('INSERT INTO tasks (id, description) VALUES (uuid(), ?)', ['Review the project plan']);
+const checkpoint = await database.requestCheckpoint();
+await checkpoint.waitForSync();
+// The pending write has uploaded and its server state has synced locally.
+```
+
+This behavior relies on `uploadData()` returning only after your backend has committed the changes to the source database.
+
+### Async Upload Backends (Team/Enterprise)
+
+If `uploadData()` queues writes for later processing rather than committing them synchronously, implement the optional `postCheckpointRequest` method on your connector. This requires a `checkpoint_requests` event definition in your sync config and is available on [Team and Enterprise](https://www.powersync.com/pricing) plans:
+
+```ts
+class MyBackendConnector implements PowerSyncBackendConnector {
+  // ... also implement fetchCredentials and uploadData
+
+  async postCheckpointRequest(clientId: string, requestId: string): Promise<string> {
+    const response = await myBackend.createCheckpointRequest(clientId, requestId);
+    return response.checkpointRequestId;
+  }
+}
+```
+
+See [Checkpoint Requests](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests) for the full setup guide.
+
 ## ORM & Raw Tables
 
 These advanced topics are in separate files — load only when needed:
@@ -728,7 +800,7 @@ The Rust-based sync client is now the only sync client. The legacy JavaScript cl
 
 ### QueryStore
 
-`useSuspenseQuery` uses a `QueryStore` (one per `PowerSyncDatabase`, stored in a `WeakMap`). Caches `WatchedQuery` instances keyed by `"${sql} -- ${JSON.stringify(params)} -- ${JSON.stringify(options)}"`. Evicted when listener count reaches 0. `useSuspenseQuery` and `useQuery` with the same SQL/params/options share the same underlying `WatchedQuery`.
+`useSuspenseQuery` uses a `QueryStore` (one per `PowerSyncDatabase`, stored in a `WeakMap`). Caches `WatchedQuery` instances keyed by `"${sql} -- ${JSON.stringify(params)} -- ${JSON.stringify(options)}"`; Evicted when listener count reaches 0. `useSuspenseQuery` and `useQuery` with the same SQL/params/options share the same underlying `WatchedQuery`.
 
 ### Op Types (Internal Sync vs CRUD)
 

--- a/skills/powersync/references/sdks/powersync-kotlin.md
+++ b/skills/powersync/references/sdks/powersync-kotlin.md
@@ -2,7 +2,7 @@
 name: powersync-kotlin
 description: PowerSync Kotlin SDK — schema, queries, sync lifecycle, and backend connectors
 metadata:
-  tags: kotlin, android, ios, sqlite, offline-first
+  tags: kotlin, android, ios, sqlite, offline-first, checkpoint-requests
 ---
 
 # PowerSync Kotlin SDK
@@ -17,6 +17,7 @@ metadata:
 - [Compose Integration](#compose-integration)
 - [Sync Status](#sync-status)
 - [Sync Streams](#sync-streams)
+- [Checkpoint Requests (Alpha)](#checkpoint-requests-alpha)
 - [Background Sync (Android)](#background-sync-android)
 
 Best practices for building apps with the PowerSync Kotlin SDK.
@@ -421,6 +422,91 @@ stream.unsubscribeAll()
 ```
 
 Same stream name with different parameters creates separate subscriptions. Subscribing while offline is supported — subscriptions are tracked locally and sent on next connect.
+
+## Checkpoint Requests (Alpha)
+
+Checkpoint requests let you confirm that the local database has caught up to a specific server state. Use this when you need to know that server changes are available locally: after a local write to wait for the result to sync back, in a pull-to-refresh flow, or when a user opens a link that refers to data that may not have synced yet.
+
+Requires PowerSync Service v1.24.0+. .NET and Rust SDKs do not yet support checkpoint requests.
+
+To opt in, pass `CheckpointMode.Requests()` in `SyncOptions` to `connect()`:
+
+```kotlin
+database.connect(
+    connector,
+    options = SyncOptions(
+        checkpointMode = CheckpointMode.Requests(),
+    )
+)
+```
+
+Without this option, calling `requestCheckpoint()` throws an error. Kotlin uses `Long` for checkpoint IDs (unlike the JavaScript and Dart SDKs, which use strings).
+
+### Waiting for the Latest Server Data
+
+```kotlin
+val checkpoint = database.requestCheckpoint()
+withTimeout(30.seconds) {
+    checkpoint.waitForSync()
+}
+// Local queries now reflect server state from when requestCheckpoint() was called.
+```
+
+`requestCheckpoint()` requires the database to be connected or connecting. If offline, the call suspends until the Service is reachable. Cancelling `waitForSync` or reaching a timeout does not remove the checkpoint. It only limits how long you wait for the checkpoint to apply locally.
+
+### Error Handling
+
+```kotlin
+try {
+    val checkpoint = database.requestCheckpoint()
+    withTimeout(30.seconds) {
+        checkpoint.waitForSync()
+    }
+} catch (e: TimeoutCancellationException) {
+    showRefreshMessage("The refresh timed out. Try again.")
+} catch (e: CheckpointRequestException.Disconnected) {
+    showRefreshMessage("Reconnect before refreshing again.")
+} catch (e: Exception) {
+    // Other checkpoint exceptions
+}
+```
+
+### Relationship to Local Writes
+
+When checkpoint requests are enabled, the SDK creates an internal request after each upload queue flush. You do not need to call `requestCheckpoint()` for your own writes. If you create a request while local writes are pending, waiting on it also waits for those writes to upload and their results to sync back:
+
+```kotlin
+database.execute(
+    "INSERT INTO tasks (id, description) VALUES (uuid(), ?)",
+    listOf("Review the project plan")
+)
+val checkpoint = database.requestCheckpoint()
+checkpoint.waitForSync()
+// The pending write has uploaded and its server state has synced locally.
+```
+
+This behavior relies on `uploadData()` returning only after your backend has committed the changes to the source database.
+
+### Async Upload Backends (Team/Enterprise)
+
+If `uploadData()` queues writes for later processing rather than committing them synchronously, implement `CustomCheckpointRequestConnector` on your connector. This requires a `checkpoint_requests` event definition in your sync config and is available on [Team and Enterprise](https://www.powersync.com/pricing) plans:
+
+```kotlin
+class MyBackendConnector: PowerSyncBackendConnector(), CustomCheckpointRequestConnector {
+    override suspend fun fetchCredentials(): PowerSyncCredentials? = TODO()
+    override suspend fun uploadData(database: PowerSyncDatabase) = TODO()
+
+    override suspend fun postCheckpointRequest(
+        clientId: String,
+        requestId: Long
+    ): Long {
+        val response = myBackend.createCheckpointRequest(clientId, requestId)
+        return response.checkpointRequestId
+    }
+}
+```
+
+See [Checkpoint Requests](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests) for the full setup guide.
 
 ## Background Sync (Android)
 

--- a/skills/powersync/references/sdks/powersync-swift.md
+++ b/skills/powersync/references/sdks/powersync-swift.md
@@ -163,7 +163,7 @@ See [sync-config.md](references/sync-config.md) for how to subscribe to Sync Str
 
 Checkpoint requests let you confirm that the local database has caught up to a specific server state. Use this when you need to know that server changes are available locally: after a local write to wait for the result to sync back, in a pull-to-refresh flow, or when a user opens a link that refers to data that may not have synced yet.
 
-Requires Swift SDK v1.16.0+, PowerSync Service v1.24.0+, and `checkpointMode: .requests()` set in `ConnectOptions`. Support for other SDKs is planned.
+Requires Swift SDK v1.16.0+, PowerSync Service v1.24.0+, and `checkpointMode: .requests()` set in `ConnectOptions`. JavaScript, Dart, and Kotlin SDKs also support checkpoint requests; .NET and Rust do not yet.
 
 ```swift
 try await database.connect(
@@ -184,7 +184,7 @@ try await checkpoint.waitForSync(timeout: 30)
 // Local queries now reflect server state from when requestCheckpoint() was called.
 ```
 
-`requestCheckpoint()` requires that the database is connected or connecting. If offline, the call suspends until the Service is reachable. Cancel the calling task to stop waiting. The `timeout` passed to `waitForSync(timeout:)` only limits waiting for the checkpoint to apply locally.
+`requestCheckpoint()` requires that the database is connected or connecting. If offline, the call suspends until the Service is reachable. Cancel the calling task to stop waiting. Aborting `waitForSync(timeout:)` or reaching the timeout does not remove the checkpoint. It only limits how long you wait for the checkpoint to apply locally.
 
 ### Error Handling
 


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/595

### What changed in docs

PR #595 expanded checkpoint request support from Swift-only to JavaScript/TypeScript, Dart, and Kotlin. The warning on the checkpoint-requests page was updated, and code examples for connecting with `checkpointMode`, calling `requestCheckpoint()` and `waitForSync()`, handling errors, using checkpoint requests with local writes, and implementing `CustomCheckpointRequestConnector` were added for all three newly-supported SDKs.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-swift.md`: Removed stale "Support for other SDKs is planned." text; added note that JS, Dart, and Kotlin now support checkpoint requests (.NET and Rust do not yet); clarified that aborting `waitForSync` does not remove the checkpoint.
- `skills/powersync/references/sdks/powersync-js.md`: Added "Checkpoint Requests (Alpha)" section covering the `checkpointMode: 'requests'` connect option, `requestCheckpoint()`/`waitForSync()` pattern, `AbortSignal`-based timeout, error handling, local-write relationship, and optional `postCheckpointRequest` connector method; noted that checkpoint IDs are strings in JS; updated frontmatter tags and table of contents.
- `skills/powersync/references/sdks/powersync-dart.md`: Added "Checkpoint Requests (Alpha)" section covering `SyncOptions(checkpointMode: .requests())`, `requestCheckpoint()`/`waitForSync()` with `abortTrigger`, error handling via `AbortException`, local-write relationship, and `CustomCheckpointRequestConnector` mixin; noted that checkpoint IDs are strings in Dart; updated frontmatter tags.
- `skills/powersync/references/sdks/powersync-kotlin.md`: Added "Checkpoint Requests (Alpha)" section covering `CheckpointMode.Requests()` in `SyncOptions`, `requestCheckpoint()`/`waitForSync()` with `withTimeout`, error handling via `TimeoutCancellationException` and `CheckpointRequestException.Disconnected`, local-write relationship, and `CustomCheckpointRequestConnector` implementation; noted that Kotlin uses `Long` for checkpoint IDs (unlike JS/Dart strings); updated frontmatter tags and table of contents.

### Notes for reviewer

The Dart `waitForSync` abort trigger in the docs uses `Future.pause(Duration(seconds: 30))`. The skill uses `Future.delayed(Duration(seconds: 30))` because `Future.pause` may not be a standard Dart API — the reviewer should confirm the correct idiom matches the actual Dart SDK and correct if needed.

No new skill files were created. All changes fit within the four existing SDK reference files. The `powersync-dotnet.md` and any Rust skill file were intentionally left untouched, as .NET and Rust do not yet support checkpoint requests.

https://claude.ai/code/session_01UQF2nQbizZHxb8SwbeaBwr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQF2nQbizZHxb8SwbeaBwr)_