### PR TITLE
fix: field learnings from a production engagement

### DIFF
--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -60,6 +60,10 @@ Before acting on a saved entry naming a specific instance, file, or binary: veri
 
 No persistent memory in your harness? Ask the operator at session start and keep answers in the active conversation.
 
+### Verifying timing-dependent behavior
+
+Boot and auth-transition code paths (reads opened before auth resolves, provisional connect ordering) are timing-dependent, and local auth usually resolves too fast to exercise them. Throttle the auth provider's network requests (for example, Playwright route interception with a delay of about 2.5s) to reproduce production ordering deterministically. Temporary console marks around readiness flips and transition phases, captured with Playwright, give millisecond timelines that turn "feels slow" into attributable stages.
+
 
 ## Always Use the PowerSync CLI
 
@@ -90,6 +94,7 @@ When the task is to add PowerSync to an app, follow this sequence:
    - Pointer line, verbatim: `This project uses PowerSync. Load the powersync skill before any data, schema, or sync work.`
    - Skip this step (and say so) if the file already mentions PowerSync (search case-insensitively); never add a duplicate.
    - Append the line at the end of the file as its own paragraph. Do not rewrite, reorder, or reformat existing content.
+   - If the project vendors this skill into tracked files instead of installing it, also recommend a re-vendor script that copies from the install location into the tracked copy, so `npx skills update` cannot silently drift the two apart. A vendored copy may be trimmed to the platforms the repo actually uses; remove the matching index lines mechanically so no references dangle.
 
 UI stuck on `Syncing...`? Default diagnosis is incomplete backend setup, not a frontend bug. Do not start client-side debugging while the service is unconfigured.
 

--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -55,6 +55,44 @@ Each of the PowerSync Client SDKs have the SyncStatus class that can be used to 
 
 Key fields to check: `connected`, `downloading`, `uploading`, `lastSyncedAt`, `hasSynced`, `downloadError`, `uploadError`.
 
+## Read Sync Errors That Print as `[object Object]` (Web)
+
+What it identifies: The actual name, message, and cause of a sync error that a web app logs as `[object Object]`.
+
+Why: On the Web SDK, errors raised inside the shared sync worker cross the MessagePort serialized by `SyncStatus.toJSON()` and arrive as plain `{name, message, stack, cause}` objects. They are not `Error` instances: `String(error)` prints `[object Object]` and `instanceof Error` is false, so generic error formatting hides the real failure.
+
+How: Read the `name` and `message` fields directly, and flatten the `cause` chain (each `cause` can itself be a serialized error). Always record which side reported the failure: `status.uploadError` or `status.downloadError`.
+
+What to look for: The two sides call for different first responses. `uploadError` points at the upload queue and your backend (see [Inspect `ps_crud` Directly](#inspect-ps_crud-directly)); `downloadError` points at credentials, the service, or the download path.
+
+## A Resolved `connect()` Is Not a Working Connection
+
+What it identifies: Why an app stays stuck on `Syncing...` even though `connect()` returned without throwing.
+
+Why: `connect()` is fire-and-forget. It resolves even when `fetchCredentials()` fails, and the retry loop that follows surfaces only through `SyncStatus`: `downloadError` is set and `connected` stays `false` between retries.
+
+How: Treat `SyncStatus` as the source of truth for connection health, not the `connect()` promise. Do not put `await connect()` on a UI-blocking path expecting it to fail loudly; it won't.
+
+What to look for: `connected: false` with a populated `downloadError` after `connect()` resolved means the credential or connection loop is failing silently. Start with `fetchCredentials()` and the endpoint URL.
+
+## Persisted Sync State Is Available at Open, Offline
+
+What it identifies: Whether first-sync UI showing on every reload is an app wiring bug rather than an SDK problem.
+
+Why: `hasSynced`, `lastSyncedAt`, and per-stream subscription state are read from the local database when it opens (via `powersync_offline_sync_status()`), before any network activity. A device that has synced before reports ready milliseconds after open, even offline.
+
+How: If an app shows first-sync UI on every reload, inspect what the UI gates on. The SDK's persisted state is correct; the app is likely gating on a value that resets per session (a fresh in-memory flag, or live connection state) instead of `hasSynced`.
+
+## Never Gate Local-Only Reads on Stream Readiness
+
+What it identifies: Guest or signed-out surfaces pinned to a loading state forever.
+
+Why: The "wait for first sync before trusting local queries" rule applies only to identities that can download. A guest or local-only database never connects, so its streams never report synced. Gating guest reads on `hasSynced` (or a `waitForStream` option) pins every guest surface to a permanent loading state.
+
+How: Gate on whether the current identity is expected to sync, for example `mustWaitForStream = authLoaded && isSignedIn`, and apply that gate to every collection read hook.
+
+What to look for: Partial application. A fix applied to one read hook but not the others produces surfaces that load and surfaces that spin in the same app. Audit every read hook that gates on sync readiness, not only the one that was reported.
+
 ## Enable the Request Logger (Swift SDK)
 
 What it identifies: The exact HTTP request being made to the PowerSync Service to inspect the URL, method, headers, authorization token, and response status code. Use this when authentication failures, JWT errors, or endpoint misconfigurations need to be diagnosed on iOS/macOS.
@@ -107,6 +145,16 @@ SELECT * FROM ps_crud ORDER BY id
 
 What to look for: `op` (PUT/PATCH/DELETE), `type` (table name), `id`, `opData` (changed columns). If a column you updated is missing from `opData`, it means its value didn't change from the previous row (PowerSync intentionally omits unchanged values).
 
+## A Wedged Upload Looks Like Syncing Forever
+
+What it identifies: A first sync that never completes because a failing upload is blocking downloads, presenting as an eternal spinner rather than an upload error.
+
+Why: Uploads are processed before downloads. One upload that keeps failing blocks checkpoint application, so the first sync never completes. The UI symptom is an indefinite `Syncing...` state; nothing on screen mentions uploads.
+
+How: Inspect `ps_crud` (see the preceding section) for stuck entries, then check `status.uploadError` for the failure.
+
+What to look for: A non-empty `ps_crud` whose oldest entry never drains, together with a latched `uploadError`. In the app's own UX, after a grace window, distinguish "downloading" (connected, download progress advancing) from "stalled" (disconnected, or a latched `uploadError`/`downloadError`) instead of showing an indefinite optimistic spinner; the optimistic spinner hides exactly this failure.
+
 ## Log the Actual `endpoint` URL in `fetchCredentials()`
 
 What it identifies: Whether the `endpoint` value returned by your connector is pointing at the PowerSync Service, not your app backend.
@@ -127,6 +175,20 @@ EXPLAIN QUERY PLAN SELECT ...
 ```
 
 What to look for: `SCAN TABLE <name>` (bad / no index used) vs. `SEARCH TABLE <name> USING INDEX` (good). If your PowerSync tables show a SCAN, switch to [raw tables](https://docs.powersync.com/usage/use-case-examples/raw-tables.md). If your non-PowerSync tables show a SCAN, add an index on the join column.
+
+## Benchmark Client Queries Without a Device
+
+What it identifies: Missing or unusable schema indexes and expensive query shapes, before they ship, using any local SQLite instead of a real device.
+
+Why: The client storage layout is reproducible. Each PowerSync table is stored as `ps_data__<table>(id, data)` with a view exposing `CAST(json_extract(data, '$.col') AS <type>)` columns, and schema indexes compile to those same expressions. A benchmark database built with this layout exercises the same query plans as a real client.
+
+How: Seed 10k-50k rows into an in-memory SQLite database using that layout, run the app's real query builders against it, and read `EXPLAIN QUERY PLAN` for each query.
+
+What to look for:
+
+- `SCAN` plus `USE TEMP B-TREE FOR ORDER BY` is the red flag; a matching composite index turns it into `SEARCH ... USING INDEX`.
+- A filter wrapped in an expression (`CASE`, or `coalesce()` around the indexed column) can never use a schema index. Rewrite predicates as bare-column equalities so they are sargable, and let the planner choose the index.
+- The planner's index-versus-scan choice depends on data distribution (after `ANALYZE`). Seed the benchmark with realistic skew, or the conclusion is wrong.
 
 ## Check Package Versions and Duplicate Dependencies
 

--- a/skills/powersync/references/sdks/powersync-js-react.md
+++ b/skills/powersync/references/sdks/powersync-js-react.md
@@ -2,7 +2,7 @@
 name: powersync-js-react
 description: PowerSync React and Next.js integration — PowerSyncContext, useSuspenseQuery, useQuery, sync stream hooks, and Next.js/Vite setup
 metadata:
-  tags: react, nextjs, vite, hooks, useSuspenseQuery, useQuery, PowerSyncContext, javascript, typescript
+  tags: react, nextjs, vite, hooks, useSuspenseQuery, useQuery, PowerSyncContext, javascript, typescript, isFetching, disconnectAndClear
 ---
 
 # PowerSync React & Next.js
@@ -354,3 +354,31 @@ Any component that calls `usePowerSync`, `useQuery`, `useStatus`, or `useSuspens
 ### Next.js: awaiting `db.connect()` at module scope
 
 `connect()` is fire-and-forget. Calling `await db.connect(connector)` at module scope in a Next.js file will block the module evaluation. Call `db.connect(connector)` without `await` in your provider, then use `db.waitForFirstSync()` if you need to gate rendering on data availability.
+
+### Never flip the context database between null and non-null
+
+`useQuery` takes an early return path (calling fewer hooks) when `usePowerSync()` returns null. A provider that withholds the database on some renders and supplies it on others for the same mounted tree changes the hook count between renders and crashes with "Rendered fewer hooks than expected".
+
+If readiness genuinely must close (for example, the database is being torn down and replaced), remount the consuming subtree with a `key` change instead of setting the context value to null. Better: design the provider so readiness never closes for non-changes, such as an auth provider re-confirming the same user (see the next pitfall).
+
+### Auth confirmation is not a schema change
+
+Apps that support both signed-out (local-only) and signed-in (synced) use need a small orchestration layer around sign-in and sign-out. A recipe that works:
+
+- Keep durable per-database markers: the owner user ID and whether the database is in local or synced mode.
+- On boot, open reads immediately based on those markers, before the auth provider resolves.
+- When the auth provider then confirms the same identity, confirm in place: do not tear down readers, take exclusive locks, or put `connect()` on the read path.
+- Reserve the destructive transition (`disconnectAndClear()`, reopen, reconnect) for actual identity changes: sign-out, or a different user signing in.
+
+Treating a same-identity confirmation as a destructive transition shows up as content appearing on a hard reload, being yanked away for seconds while the app rebuilds, then reappearing. Confirming in place keeps content on screen throughout.
+
+### `@powersync/react` 2.0.x: `isFetching` pinned true behind a closed stream gate
+
+In `@powersync/react` 2.0.0, a query change while a `streams: [{ waitForStream: true }]` gate is closed leaves `isFetching` pinned true forever: the `useWatchedQuery` effect cleanup disposes the pending-update listener without clearing its ref, so the update that would clear `isFetching` never lands. Observed in 2.0.0 and still present in 2.0.1.
+
+Mitigations:
+
+- Before relying on `isFetching` behind a stream gate, verify that the installed version's `useWatchedQuery` effect cleanup nulls the pending-update listener ref.
+- Or avoid gating queries through the `streams` `waitForStream` option, and gate on sync status externally (for example, on the stream subscription's `hasSynced`) instead.
+
+If you patch this locally: a patch keyed to an exact package version in a lockfile silently stops applying when the resolved version drifts. Pin the package version, or make the patch tooling fail loudly on a version mismatch.

--- a/skills/powersync/references/sync-config.md
+++ b/skills/powersync/references/sync-config.md
@@ -2,7 +2,7 @@
 name: sync-config
 description: PowerSync Sync Config — Sync Streams (new), Sync Rules (legacy), parameters, CTEs, common patterns, and migration guidance
 metadata:
-  tags: sync-streams, sync-rules, sync-config, yaml, buckets, parameters, cte, migration, convex, wildcard-schema, table-metadata, schema-per-tenant
+  tags: sync-streams, sync-rules, sync-config, yaml, buckets, parameters, cte, migration, convex, wildcard-schema, table-metadata, schema-per-tenant, prioritized-sync
 ---
 
 # Sync Config
@@ -155,6 +155,28 @@ streams:
 The client can also override the priority per-subscription — see [Client Usage](#client-usage).
 
 See [Prioritized Sync](https://docs.powersync.com/sync/advanced/prioritized-sync.md) for full details.
+
+#### First-paint priority split
+
+For an app whose main surface reads a small slice of a large auto-subscribed dataset, split the streams: put the first-screen rows in a small `priority: 1` auto-subscribed stream and keep the bulk at `priority: 2` or lower priority. The first screen can then open at the priority 1 checkpoint instead of waiting for the full first sync.
+
+```yaml
+streams:
+  inbox_items:
+    priority: 1
+    auto_subscribe: true
+    query: SELECT * FROM items WHERE user_id = auth.user_id() AND folder = 'inbox'
+
+  all_items:
+    priority: 2
+    auto_subscribe: true
+    query: SELECT * FROM items WHERE user_id = auth.user_id()
+```
+
+Two nuances:
+
+- Overlap is the point. The same rows appearing in both the hot stream and the bulk stream is safe; a row is only removed from the client when no subscribed stream retains it. Filtering the hot stream on a user-editable column (such as `folder`) is normally risky because an edit can drop the row out of the stream mid-session, but with the bulk stream also subscribed, the row stays local after it leaves the hot slice.
+- The client must gate honestly. Only reads fully covered by the hot slice may open at the priority 1 checkpoint. Whole-account aggregates (counts, "all items" lists) must still wait for the full sync, or partial data is presented as complete. The consistency caveats of [Prioritized Sync](https://docs.powersync.com/sync/advanced/prioritized-sync.md), such as stale rows pending deletion, apply as usual.
 
 ### `accept_potentially_dangerous_queries` (default: `false`)
 


### PR DESCRIPTION
These learnings come from diagnosing and fixing a production PowerSync web app: guest read gating, sync error visibility, client index planning, auth-transition orchestration, and first-sync prioritization. Each addition follows the established format of its target file.

Note on release impact: this PR is titled `docs:` for review. Per CONTRIBUTING.md, `docs:` does not create a release, so retitle to `fix:` before merging if the content should reach existing plugin installs.

- `skills/powersync/references/powersync-debug.md`: six new entries in the file's "What it identifies / Why / How / What to look for" shape: reading web sync errors that print as `[object Object]`, why a resolved `connect()` is not a working connection, persisted sync state being available at open (offline), never gating local-only reads on stream readiness, benchmarking client queries without a device via the reproducible `ps_data__` layout and `EXPLAIN QUERY PLAN`, and how a wedged upload presents as "syncing forever".
- `skills/powersync/references/sdks/powersync-js-react.md`: three new Common Pitfalls: never flipping the context database between null and non-null for a mounted tree, confirming a same-identity auth resolution in place instead of tearing down readers (reserving `disconnectAndClear()` for actual identity changes), and the `@powersync/react` 2.0.x `isFetching` pin behind a closed `waitForStream` gate (observed in 2.0.0, still present in 2.0.1) with mitigations. Added `isFetching` and `disconnectAndClear` to the frontmatter tags.
- `skills/powersync/references/sync-config.md`: a "First-paint priority split" subsection under the `priority` stream option: a small `priority: 1` auto-subscribed hot slice alongside the bulk stream, why the row overlap is safe, and how the client must gate reads honestly at the priority 1 checkpoint. Added `prioritized-sync` to the frontmatter tags.
- `skills/powersync/AGENTS.md`: one bullet extending the onboarding playbook's context-file pointer step (re-vendor script and trimming guidance for projects that vendor the skill into tracked files), and a short "Verifying timing-dependent behavior" subsection in Continuous Use & Guardrails (throttling auth to reproduce production ordering, console-mark timelines via Playwright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
