### PR TITLE
feat: add in-skill trim script with first-run offer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,6 +69,14 @@
             {
               "file": "[/\\\\]Package\\.swift$",
               "pattern": "powersync"
+            },
+            {
+              "file": "\\.csproj$",
+              "pattern": "PowerSync"
+            },
+            {
+              "file": "[/\\\\]Podfile$",
+              "pattern": "powersync"
             }
           ]
         }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ skills/powersync/
 ├── CLAUDE.md           # Redirect to AGENTS.md (for Claude Code)
 ├── AGENTS.md           # Primary entry point for all agents (Cursor, Codex, Claude, etc.)
 ├── SKILL.md            # Entry point for skills.sh (includes YAML frontmatter + same content as AGENTS.md)
+├── scripts/
+│   └── trim.mjs        # Prunes unused platform references from an installed copy, with operator approval
 └── references/
     ├── sync-config.md
     ├── powersync-service.md
@@ -84,6 +86,15 @@ metadata:
 ```
 
 Tags are used by skill routing systems for auto-activation. Use terms developers would type when asking for help: SDK names, API method names (`uploadData`, `fetchCredentials`), error terms, feature names.
+
+### Skill scripts
+
+Files under `skills/powersync/scripts/` ship inside every installed copy and run in consumer repos with no `node_modules`, so they must be plain Node ESM importing `node:` builtins only. `pnpm validate` enforces this and runs a syntax check on each script.
+
+When adding or removing a reference file, also update:
+
+- the `PLATFORMS` table in `skills/powersync/scripts/trim.mjs` (validated by `pnpm validate` for `references/sdks/` files), and
+- the `relevance.signals.manifestDeps` patterns in `.claude-plugin/marketplace.json` if the change introduces a new platform.
 
 ### Key rules (apply to all files)
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ Installed skills do not update themselves. To get the latest release:
 - Claude Code plugin: `/plugin marketplace update powersync`, then `/plugin update powersync-skills@powersync`
 - Gemini CLI: `gemini skills uninstall powersync`, then reinstall
 
+## Trimming an installed copy
+
+The skill ships reference files for every PowerSync platform (JS/TS, Flutter, Kotlin, Swift, .NET, Terraform). Installed copies include `scripts/trim.mjs`, which detects the platforms a repo uses and, with your approval, prunes the unused reference files from that copy to reduce agent context size.
+
+Agents offer this automatically on first use (see the skill's SKILL.md). To run it yourself from your repo root (adjust the path to where your agent installs skills):
+
+```bash
+node .claude/skills/powersync/scripts/trim.mjs          # read-only report
+node .claude/skills/powersync/scripts/trim.mjs --apply  # prune unused files
+```
+
+Notes:
+
+- The script only changes files inside the installed skill directory and makes no network requests.
+- The decision is recorded in `.trim-state.json` inside the skill directory so the offer is not repeated. Delete that file to decide again.
+- Shared installs (the Claude Code plugin cache, user-level installs) are refused, since one repo's trim would affect every project.
+- Updating or reinstalling restores the full copy and clears the recorded decision, so the offer repeats on the restored copy.
+
 ## Usage
 
 Once skills are installed, agents will automatically use relevant information when working on tasks relating to PowerSync. 
@@ -96,10 +114,10 @@ export SNYK_TOKEN=<your-token>
 uvx snyk-agent-scan@latest scan skills/powersync --json
 ```
 
-Without a Snyk account, use the rate-limited demo endpoint behind Snyk's [Skill Inspector](https://labs.snyk.io/experiments/skill-scan/):
+Without a Snyk account, use the rate-limited demo endpoint behind Snyk's [Skill Inspector](https://labs.snyk.io/experiments/skill-scan/). Pin version 0.5.17: newer releases target a newer analysis API and are rejected by the demo endpoint without a token.
 
 ```bash
-SNYK_CLI_USE=true uvx snyk-agent-scan@latest scan skills/powersync \
+SNYK_CLI_USE=true uvx snyk-agent-scan@0.5.17 scan skills/powersync \
   --analysis-url "https://labs.snyk.io/experiments/skill-scan/api/agent-scan/analysis-machine" \
   --json
 ```

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -8,6 +8,7 @@
  */
 
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -139,13 +140,13 @@ function validateSkillMd(skillDir, skillName) {
 function extractReferences(content) {
   const refs = new Set();
 
-  // Backtick references to .md files: `references/sdks/powersync-js.md`
-  for (const m of content.matchAll(/`((?:references|scripts|assets)\/[^`]+\.md)`/g)) {
+  // Backtick references to .md/.mjs files: `references/sdks/powersync-js.md`
+  for (const m of content.matchAll(/`((?:references|scripts|assets)\/[^`]+\.(?:md|mjs))`/g)) {
     refs.add(m[1]);
   }
 
-  // Markdown link references to local .md files: [text](references/foo.md)
-  for (const m of content.matchAll(/\]\(((?:references|scripts|assets)\/[^)]+\.md)\)/g)) {
+  // Markdown link references to local .md/.mjs files: [text](references/foo.md)
+  for (const m of content.matchAll(/\]\(((?:references|scripts|assets)\/[^)]+\.(?:md|mjs))\)/g)) {
     refs.add(m[1]);
   }
 
@@ -187,6 +188,56 @@ function validateReferences(skillDir, skillName) {
     pass(`all ${totalRefs} file references resolve`);
   } else if (totalRefs === 0) {
     warn('no file references found');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2b. Validate skill scripts
+// ---------------------------------------------------------------------------
+
+// Skill scripts ship inside the skill and run in consumer repos that have no
+// node_modules, so they must parse standalone and import node builtins only.
+
+function validateScripts(skillDir, skillName) {
+  const scriptsDir = join(skillDir, 'scripts');
+  if (!existsSync(scriptsDir)) return;
+  console.log(`\n[Scripts] ${skillName}`);
+
+  for (const name of readdirSync(scriptsDir).filter((n) => n.endsWith('.mjs'))) {
+    const file = join(scriptsDir, name);
+    try {
+      execFileSync(process.execPath, ['--check', file], { stdio: 'pipe' });
+      pass(`scripts/${name} parses`);
+    } catch (e) {
+      error(`scripts/${name} has a syntax error: ${e.stderr?.toString().trim() || e.message}`);
+      continue;
+    }
+
+    const content = readFileSync(file, 'utf-8');
+    const specifiers = [...content.matchAll(/^\s*(?:import|export)\b[^'"]*['"]([^'"]+)['"]/gm)].map((m) => m[1]);
+    const external = specifiers.filter((s) => !s.startsWith('node:'));
+    if (external.length > 0) {
+      error(`scripts/${name} imports non-builtin modules: ${external.join(', ')} (use node: builtins only)`);
+    } else {
+      pass(`scripts/${name} imports node builtins only (${specifiers.length} imports)`);
+    }
+  }
+
+  // trim.mjs must list every SDK reference file, or a newly added file would
+  // silently survive every trim.
+  const trimPath = join(scriptsDir, 'trim.mjs');
+  const sdksDir = join(skillDir, 'references', 'sdks');
+  if (existsSync(trimPath) && existsSync(sdksDir)) {
+    const trimSource = readFileSync(trimPath, 'utf-8');
+    let missing = 0;
+    for (const name of readdirSync(sdksDir).filter((n) => n.endsWith('.md'))) {
+      const rel = `references/sdks/${name}`;
+      if (!trimSource.includes(rel)) {
+        error(`scripts/trim.mjs does not list ${rel}; add it to the PLATFORMS table`);
+        missing++;
+      }
+    }
+    if (missing === 0) pass('scripts/trim.mjs lists every references/sdks file');
   }
 }
 
@@ -380,6 +431,7 @@ if (!existsSync(skillsRoot)) {
     const skillDir = join(skillsRoot, dir.name);
     validateSkillMd(skillDir, dir.name);
     validateReferences(skillDir, dir.name);
+    validateScripts(skillDir, dir.name);
   }
 }
 

--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -23,6 +23,10 @@ If a sentence is ambiguous, default to the operator interpretation.
 
 Shortcut requested? Operator must say so explicitly (e.g. "no CLI, dashboard only").
 
+## First use in a repo (trim offer)
+
+If `.trim-state.json` does not exist next to `SKILL.md`, follow SKILL.md § "First Use in a Repo: Offer to Trim": run `node scripts/trim.mjs` (read-only report), show the result to the operator, and trim only with explicit operator approval (`--apply`). Record a decline with `--decline`. Skip silently if the script refuses or detects no PowerSync usage yet.
+
 ## Continuous Use & Guardrails (existing projects)
 
 The onboarding playbook below assumes a fresh project. On an **existing** project the rules in this section take precedence. Continuous-use sessions are where agents do the most damage — assume nothing about the linked instance, scope, or environment.
@@ -94,7 +98,7 @@ When the task is to add PowerSync to an app, follow this sequence:
    - Pointer line, verbatim: `This project uses PowerSync. Load the powersync skill before any data, schema, or sync work.`
    - Skip this step (and say so) if the file already mentions PowerSync (search case-insensitively); never add a duplicate.
    - Append the line at the end of the file as its own paragraph. Do not rewrite, reorder, or reformat existing content.
-   - If the project vendors this skill into tracked files instead of installing it, also recommend a re-vendor script that copies from the install location into the tracked copy, so `npx skills update` cannot silently drift the two apart. A vendored copy may be trimmed to the platforms the repo actually uses; remove the matching index lines mechanically so no references dangle.
+   - If the project vendors this skill into tracked files instead of installing it, also recommend a re-vendor script that copies from the install location into the tracked copy, so `npx skills update` cannot silently drift the two apart. A vendored copy may be trimmed to the platforms the repo actually uses with the operator's approval; use `scripts/trim.mjs` in this skill so no references dangle.
 
 UI stuck on `Syncing...`? Default diagnosis is incomplete backend setup, not a frontend bug. Do not start client-side debugging while the service is unconfigured.
 

--- a/skills/powersync/SKILL.md
+++ b/skills/powersync/SKILL.md
@@ -35,6 +35,17 @@ If a sentence is ambiguous, default to the operator interpretation. Full legend 
 - **Confirm the target instance before any mutating command** (`deploy`, `destroy`, `stop`, `link --create`, `pull instance`). Never deploy to an instance not authorized by the operator. Treat production as off-limits unless explicitly approved.
 - **Use project memory.** If your harness supports it, persist the CLI invocation, sync-config path, authorized instance ids + environment (dev/staging/prod), and allowed scope of changes. Verify saved values still match reality before acting on them. See `AGENTS.md` § "Continuous Use & Guardrails".
 
+## First Use in a Repo: Offer to Trim (agents)
+
+This copy ships reference files for every PowerSync platform. On your first use of this skill in a repo, check for `.trim-state.json` next to this file. If it exists, the operator already decided; skip this section.
+
+Otherwise run `node scripts/trim.mjs` from this skill's directory. The default run is a read-only report: it detects which PowerSync platforms this repo uses and lists the reference files this copy does not need. It works on this installed copy only, makes no network requests, and is reversible by reinstalling the skill. If it refuses (shared or source install) or detects no PowerSync usage yet, skip this section silently. Otherwise show the report to the operator and ask whether to trim this installed copy. Never trim without explicit operator approval.
+
+- Operator approves: run `node scripts/trim.mjs --apply` (add `--keep <platforms>` for platforms the operator wants to keep anyway).
+- Operator declines: run `node scripts/trim.mjs --decline` so the operator is not asked again.
+
+Reinstalling or `npx skills update` restores the full copy and clears the recorded decision; offering again after an update is expected.
+
 ## What to Load for Your Task
 
 | Task | Start with | Load on demand |

--- a/skills/powersync/scripts/trim.mjs
+++ b/skills/powersync/scripts/trim.mjs
@@ -1,0 +1,522 @@
+#!/usr/bin/env node
+
+/**
+ * Trims this installed copy of the powersync skill to the platforms a repo
+ * actually uses, with the operator's approval.
+ *
+ * The default run is a read-only report: it detects which PowerSync platforms
+ * the surrounding repo uses and lists the reference files this copy does not
+ * need. Only --apply changes files, and only inside this skill's own
+ * directory. The script makes no network requests and imports node builtins
+ * only. Reinstalling the skill or running `npx skills update` restores the
+ * full copy.
+ *
+ * Usage:
+ *   node scripts/trim.mjs                 read-only detect + report
+ *   node scripts/trim.mjs --apply         prune unused reference files
+ *   node scripts/trim.mjs --decline       record "keep the full copy", ask never again
+ *   node scripts/trim.mjs --repo <path>   override repo root discovery
+ *   node scripts/trim.mjs --keep <p1,p2>  keep platforms regardless of detection
+ *   node scripts/trim.mjs --json          machine-readable report
+ *
+ * Exit codes: 0 success or recorded no-op, 1 verification failure (nothing
+ * written), 2 refused or not applicable (shared install, skill source repo,
+ * no repo root, nothing detected).
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, statSync } from 'node:fs';
+import { join, resolve, dirname, relative, sep, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+
+const SKILL_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const STATE_FILE = '.trim-state.json';
+const INDEX_FILES = ['SKILL.md', 'AGENTS.md'];
+const UPSTREAM = 'https://github.com/powersync-ja/agent-skills';
+
+// Platform names -> the reference files kept when that platform is detected.
+// Adding or removing a file under references/sdks/ requires updating this
+// table (pnpm validate in the source repo enforces it).
+const PLATFORMS = {
+  js: {
+    label: 'JavaScript / TypeScript',
+    files: [
+      'references/sdks/powersync-js.md',
+      'references/sdks/powersync-js-node.md',
+      'references/sdks/powersync-js-orm.md',
+      'references/sdks/powersync-js-react.md',
+      'references/sdks/powersync-js-react-native.md',
+      'references/sdks/powersync-js-tanstack.md',
+      'references/sdks/powersync-js-vue.md',
+    ],
+  },
+  dart: { label: 'Dart / Flutter', files: ['references/sdks/powersync-dart.md'] },
+  kotlin: { label: 'Kotlin', files: ['references/sdks/powersync-kotlin.md'] },
+  swift: { label: 'Swift', files: ['references/sdks/powersync-swift.md'] },
+  dotnet: { label: '.NET', files: ['references/sdks/powersync-dotnet.md'] },
+  terraform: { label: 'Terraform', files: ['references/terraform.md'] },
+};
+
+const MATCHERS = [
+  { platform: 'js', match: (n) => n === 'package.json', pattern: /"@powersync\/|wa-sqlite/ },
+  { platform: 'dart', match: (n) => n === 'pubspec.yaml', pattern: /powersync/i },
+  {
+    platform: 'kotlin',
+    match: (n) => n === 'build.gradle' || n === 'build.gradle.kts' || n === 'libs.versions.toml',
+    pattern: /com\.powersync/,
+  },
+  { platform: 'swift', match: (n) => n === 'Package.swift' || n === 'Podfile', pattern: /powersync/i },
+  { platform: 'dotnet', match: (n) => n.endsWith('.csproj'), pattern: /powersync/i },
+  { platform: 'terraform', match: (n) => n.endsWith('.tf'), pattern: /powersync/i },
+];
+
+const SKIP_DIRS = new Set([
+  'node_modules', 'dist', 'build', 'out', 'Pods', 'vendor', 'target', 'bin', 'obj',
+  'DerivedData', 'coverage',
+]);
+const MAX_DEPTH = 8;
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { apply: false, decline: false, json: false, repo: null, keep: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--apply') args.apply = true;
+    else if (a === '--decline') args.decline = true;
+    else if (a === '--json') args.json = true;
+    else if (a === '--repo') args.repo = argv[++i];
+    else if (a === '--keep') args.keep = (argv[++i] || '').split(',').map((s) => s.trim()).filter(Boolean);
+    else {
+      console.error(`Unknown argument: ${a}`);
+      console.error('Usage: node scripts/trim.mjs [--apply | --decline] [--repo <path>] [--keep <p1,p2>] [--json]');
+      process.exit(2);
+    }
+  }
+  if (args.apply && args.decline) {
+    console.error('--apply and --decline are mutually exclusive');
+    process.exit(2);
+  }
+  const invalid = args.keep.filter((k) => !PLATFORMS[k]);
+  if (invalid.length > 0) {
+    console.error(`Unknown --keep platform(s): ${invalid.join(', ')} (valid: ${Object.keys(PLATFORMS).join(', ')})`);
+    process.exit(2);
+  }
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// Install classification
+// ---------------------------------------------------------------------------
+
+function caseFold(p) {
+  return process.platform === 'win32' ? p.toLowerCase() : p;
+}
+
+function isInside(parent, child) {
+  const rel = relative(caseFold(parent), caseFold(child));
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+function classifyInstall(repoArg) {
+  // Plugin-cache installs are shared by every project on the machine, so a
+  // per-repo trim must never touch them. Checked before repo-root discovery
+  // because a dotfiles .git in $HOME could otherwise masquerade as a repo.
+  const segs = caseFold(SKILL_DIR).split(sep);
+  if ((segs.includes('.claude') && segs.includes('plugins')) || segs.includes('marketplaces')) {
+    return { kind: 'shared', detail: 'this copy lives in a plugin cache shared across projects' };
+  }
+
+  let root = null;
+  if (repoArg) {
+    root = resolve(repoArg);
+    if (!existsSync(root)) return { kind: 'unknown', detail: `--repo path not found: ${root}` };
+  } else {
+    let dir = SKILL_DIR;
+    for (;;) {
+      if (existsSync(join(dir, '.git'))) { root = dir; break; }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+    if (!root) {
+      const cwd = process.cwd();
+      const hasManifest = readdirSync(cwd).some((n) => MATCHERS.some((m) => m.match(n)));
+      if (hasManifest && isInside(cwd, SKILL_DIR)) root = cwd;
+    }
+  }
+
+  if (root) {
+    if (existsSync(join(root, '.claude-plugin', 'marketplace.json'))) {
+      const rel = relative(root, SKILL_DIR);
+      if (rel === join('skills', 'powersync') || rel.startsWith('skills' + sep)) {
+        return { kind: 'source', detail: 'this is the skill source repository; trim only installed copies' };
+      }
+    }
+    if (!isInside(root, SKILL_DIR)) {
+      return { kind: 'unknown', detail: 'the skill directory is not inside the repo root; pass --repo <path>' };
+    }
+    return { kind: 'repo-local', root };
+  }
+
+  if (isInside(homedir(), SKILL_DIR)) {
+    return { kind: 'shared', detail: 'this looks like a user-level install shared across projects' };
+  }
+  return { kind: 'unknown', detail: 'no repo root found; pass --repo <path>' };
+}
+
+// ---------------------------------------------------------------------------
+// Platform detection
+// ---------------------------------------------------------------------------
+
+function detectPlatforms(root) {
+  const found = {};
+  const walk = (dir, depth) => {
+    if (Object.keys(found).length === MATCHERS.length) return;
+    let entries;
+    try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      if (Object.keys(found).length === MATCHERS.length) return;
+      const name = entry.name;
+      if (entry.isDirectory()) {
+        // Dot-dirs are skipped so installed skill copies never count as usage.
+        if (!name.startsWith('.') && !SKIP_DIRS.has(name) && depth < MAX_DEPTH) {
+          walk(join(dir, name), depth + 1);
+        }
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const applicable = MATCHERS.filter((m) => !found[m.platform] && m.match(name));
+      if (applicable.length === 0) continue;
+      const full = join(dir, name);
+      let size;
+      try { size = statSync(full).size; } catch { continue; }
+      if (size > MAX_MANIFEST_BYTES) continue;
+      let lines;
+      try { lines = readFileSync(full, 'utf-8').split(/\r?\n/); } catch { continue; }
+      for (const m of applicable) {
+        const idx = lines.findIndex((l) => m.pattern.test(l));
+        if (idx !== -1) {
+          found[m.platform] = {
+            file: relative(root, full).split(sep).join('/'),
+            line: idx + 1,
+            text: lines[idx].trim().slice(0, 80),
+          };
+        }
+      }
+    }
+  };
+  walk(root, 0);
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Index rewriting (SKILL.md and AGENTS.md)
+// ---------------------------------------------------------------------------
+
+const TABLE_SEPARATOR = /^\|[\s\-:|]*$/;
+
+function dropOrphanTables(lines) {
+  const result = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (!lines[i].startsWith('|')) {
+      result.push(lines[i]);
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j < lines.length && lines[j].startsWith('|')) j++;
+    const run = lines.slice(i, j);
+    // A table reduced to its header row and separator carries no content.
+    const contentRows = run.filter((l) => !TABLE_SEPARATOR.test(l));
+    if (contentRows.length > 1) result.push(...run);
+    i = j;
+  }
+  return result;
+}
+
+function dropEmptySections(lines) {
+  const heading = /^(#{1,6})\s/;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (let i = 0; i < lines.length; i++) {
+      const m = lines[i].match(heading);
+      if (!m) continue;
+      const level = m[1].length;
+      let j = i + 1;
+      while (j < lines.length) {
+        const h = lines[j].match(heading);
+        if (h && h[1].length <= level) break;
+        j++;
+      }
+      if (lines.slice(i + 1, j).every((l) => l.trim() === '')) {
+        lines = lines.slice(0, i).concat(lines.slice(j));
+        changed = true;
+        break;
+      }
+    }
+  }
+  return lines;
+}
+
+function collapseBlankRuns(lines) {
+  const result = [];
+  let prevBlank = false;
+  for (const line of lines) {
+    const blank = line.trim() === '';
+    if (blank && prevBlank) continue;
+    result.push(line);
+    prevBlank = blank;
+  }
+  while (result.length > 0 && result[result.length - 1].trim() === '') result.pop();
+  result.push('');
+  return result;
+}
+
+function rewriteIndexContent(content, removedPaths) {
+  const eol = content.includes('\r\n') ? '\r\n' : '\n';
+  let lines = content.split(/\r?\n/);
+  lines = lines.filter((line) => !removedPaths.some((p) => line.includes(p)));
+  lines = dropOrphanTables(lines);
+  lines = dropEmptySections(lines);
+  lines = collapseBlankRuns(lines);
+  return { text: lines.join(eol), eol };
+}
+
+// The note lists removed files by base name only, so no kept file ever
+// contains a full removed path (the dangling-reference check depends on that).
+function appendTrimNote(text, eol, keptPlatforms, removedPaths) {
+  if (text.includes('## Trimmed copy')) return text;
+  const names = removedPaths.map((p) => p.split('/').pop()).join(', ');
+  const note = [
+    '## Trimmed copy',
+    '',
+    `This installed copy was trimmed on ${today()} with the operator's approval to`,
+    `match the platforms detected in this repo: ${keptPlatforms.join(', ')}. Unused`,
+    `reference documents were removed from this local copy only: ${names}.`,
+    'Reinstalling the skill or running `npx skills update` restores the full copy.',
+    `Full skill: ${UPSTREAM}`,
+  ];
+  if (removedPaths.includes('references/terraform.md')) {
+    note.push('', 'Retained warning from the removed Terraform reference: do not run `powersync deploy` against an instance managed by Terraform.');
+  }
+  return text + eol + note.join(eol) + eol;
+}
+
+// ---------------------------------------------------------------------------
+// Verification and application
+// ---------------------------------------------------------------------------
+
+function collectMdFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...collectMdFiles(full));
+    else if (entry.name.endsWith('.md')) files.push(full);
+  }
+  return files;
+}
+
+// prospective maps a skill-relative path to its planned content; pass null to
+// check what is on disk.
+function findDanglingRefs(removedPaths, prospective) {
+  const problems = [];
+  for (const file of collectMdFiles(SKILL_DIR)) {
+    const rel = relative(SKILL_DIR, file).split(sep).join('/');
+    if (removedPaths.includes(rel)) continue;
+    const content = prospective && prospective[rel] !== undefined
+      ? prospective[rel]
+      : readFileSync(file, 'utf-8');
+    for (const p of removedPaths) {
+      if (content.includes(p)) problems.push(`${rel} still references ${p}`);
+    }
+  }
+  return problems;
+}
+
+function assertInSkillDir(absPath) {
+  if (!isInside(SKILL_DIR, absPath)) {
+    console.error(`Refusing to touch a path outside the skill directory: ${absPath}`);
+    process.exit(1);
+  }
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function skillVersion() {
+  try {
+    const content = readFileSync(join(SKILL_DIR, 'SKILL.md'), 'utf-8');
+    const m = content.match(/^[ \t]+version:[ \t]*["']?([^"'\s#]+)/m);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeState(decision, detected, kept, removed) {
+  const state = {
+    schema: 1,
+    skillVersion: skillVersion() || 'unknown',
+    date: today(),
+    decision,
+    detected,
+    kept,
+    removed,
+  };
+  const file = join(SKILL_DIR, STATE_FILE);
+  assertInSkillDir(file);
+  writeFileSync(file, JSON.stringify(state, null, 2) + '\n');
+  return state;
+}
+
+function applyTrim(keptPlatforms, removedPaths, say) {
+  const prospective = {};
+  for (const name of INDEX_FILES) {
+    const file = join(SKILL_DIR, name);
+    if (!existsSync(file)) continue;
+    const { text, eol } = rewriteIndexContent(readFileSync(file, 'utf-8'), removedPaths);
+    prospective[name] = appendTrimNote(text, eol, keptPlatforms, removedPaths);
+  }
+
+  const missing = removedPaths.filter((p) => !existsSync(join(SKILL_DIR, p)));
+  if (missing.length > 0) {
+    console.error(`Files slated for removal are already absent: ${missing.join(', ')}`);
+    console.error('This copy looks partially modified. Reinstall or run `npx skills update`, then retry.');
+    process.exit(1);
+  }
+  if (!prospective['SKILL.md'] || !prospective['SKILL.md'].startsWith('---') || !prospective['SKILL.md'].includes('name: powersync')) {
+    console.error('Rewrite verification failed: SKILL.md frontmatter would be damaged. Nothing was written.');
+    process.exit(1);
+  }
+  const problems = findDanglingRefs(removedPaths, prospective);
+  if (problems.length > 0) {
+    for (const p of problems) console.error(`Dangling reference: ${p}`);
+    console.error('Rewrite verification failed. Nothing was written.');
+    process.exit(1);
+  }
+
+  for (const name of INDEX_FILES) {
+    if (prospective[name] === undefined) continue;
+    const file = join(SKILL_DIR, name);
+    assertInSkillDir(file);
+    writeFileSync(file, prospective[name]);
+    say(`rewrote ${name}`);
+  }
+  for (const p of removedPaths) {
+    const file = join(SKILL_DIR, p);
+    assertInSkillDir(file);
+    unlinkSync(file);
+    say(`removed ${p}`);
+  }
+
+  const post = findDanglingRefs(removedPaths, null);
+  if (post.length > 0) {
+    for (const p of post) console.error(`Post-write check failed: ${p}`);
+    console.error('Reinstall or run `npx skills update` to restore the full copy.');
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const say = args.json ? () => {} : (msg) => console.log(msg);
+  const emit = (obj) => { if (args.json) console.log(JSON.stringify(obj, null, 2)); };
+
+  const install = classifyInstall(args.repo);
+  if (install.kind !== 'repo-local') {
+    emit({ install: { kind: install.kind, skillDir: SKILL_DIR }, error: install.detail });
+    say(`Not applicable (${install.kind}): ${install.detail}. No changes made.`);
+    process.exit(2);
+  }
+
+  const statePath = join(SKILL_DIR, STATE_FILE);
+  if (existsSync(statePath)) {
+    let state = null;
+    try { state = JSON.parse(readFileSync(statePath, 'utf-8')); } catch { /* report raw below */ }
+    const decision = state && state.decision ? state.decision : 'unreadable';
+    emit({ install: { kind: install.kind, root: install.root }, state, applied: false });
+    if (args.apply) {
+      say(`A decision is already recorded in ${STATE_FILE} (${decision}). Delete that file to decide again.`);
+      process.exit(2);
+    }
+    say(`Decision already recorded in ${STATE_FILE}: ${decision} (${state && state.date ? state.date : 'unknown date'}). Nothing to do.`);
+    process.exit(0);
+  }
+
+  const detected = detectPlatforms(install.root);
+  const detectedList = Object.keys(PLATFORMS).filter((p) => detected[p]);
+
+  if (args.decline) {
+    const state = writeState('declined', detectedList, [], []);
+    emit({ install: { kind: install.kind, root: install.root }, state, applied: false });
+    say(`Recorded the operator's decision to keep the full copy in ${STATE_FILE}.`);
+    process.exit(0);
+  }
+
+  if (detectedList.length === 0) {
+    emit({ install: { kind: install.kind, root: install.root }, detected: {}, wouldRemove: [], applied: false });
+    say('No PowerSync usage detected in this repo yet; keeping the full copy.');
+    say('Re-run after onboarding, once a PowerSync SDK dependency exists.');
+    process.exit(args.apply ? 2 : 0);
+  }
+
+  const kept = Object.keys(PLATFORMS).filter((p) => detectedList.includes(p) || args.keep.includes(p));
+  const removedPaths = Object.keys(PLATFORMS)
+    .filter((p) => !kept.includes(p))
+    .flatMap((p) => PLATFORMS[p].files);
+
+  if (!args.json) {
+    say(`PowerSync skill trim (${args.apply ? 'apply' : 'detect'})`);
+    say(`Install: ${install.kind}  Skill: ${SKILL_DIR}  Repo: ${install.root}`);
+    say('');
+    say('Platform   Detected  Evidence');
+    for (const p of Object.keys(PLATFORMS)) {
+      const ev = detected[p];
+      const flag = ev ? 'yes' : (args.keep.includes(p) ? 'kept' : 'no');
+      say(`${p.padEnd(10)} ${flag.padEnd(9)} ${ev ? `${ev.file}:${ev.line} ${ev.text}` : ''}`.trimEnd());
+    }
+    say('');
+  }
+
+  if (removedPaths.length === 0) {
+    if (args.apply) {
+      const state = writeState('trimmed', detectedList, kept, []);
+      emit({ install: { kind: install.kind, root: install.root }, detected, state, applied: true });
+      say(`Every platform is in use; nothing to remove. Decision recorded in ${STATE_FILE}.`);
+    } else {
+      emit({ install: { kind: install.kind, root: install.root }, detected, wouldRemove: [], applied: false });
+      say('Every platform is in use; nothing to remove. Run with --apply to record that.');
+    }
+    process.exit(0);
+  }
+
+  if (!args.apply) {
+    emit({ install: { kind: install.kind, root: install.root }, detected, kept, wouldRemove: removedPaths, applied: false });
+    say(`Would remove ${removedPaths.length} unused reference file(s):`);
+    for (const p of removedPaths) say(`  ${p}`);
+    say('');
+    say('Apply:   node scripts/trim.mjs --apply');
+    say('Decline: node scripts/trim.mjs --decline   (records the decision, asks never again)');
+    process.exit(0);
+  }
+
+  applyTrim(kept, removedPaths, say);
+  const state = writeState('trimmed', detectedList, kept, removedPaths);
+  emit({ install: { kind: install.kind, root: install.root }, detected, state, applied: true });
+  say('');
+  say(`Trimmed to: ${kept.join(', ')}. Decision recorded in ${STATE_FILE}.`);
+  say('Reinstalling the skill or running `npx skills update` restores the full copy.');
+}
+
+main();


### PR DESCRIPTION
Problem: PowerSync agent-skills include unnecessary files dependant on the platform developers use e.g. if I'm building a web app I do not need the Swift SDK reference.

This PR ships scripts/trim.mjs inside the skill so installed copies can be pruned to the platforms a repo actually uses, with developer approval. Agents are instructed (SKILL.md and AGENTS.md) to offer this on first use in a repo and record the decision in .trim-state.json so the offer never repeats.

- Detection covers JS/TS, Dart, Kotlin, Swift, .NET and Terraform via manifest scanning; trimming is platform-level (the whole JS family is kept when any @powersync/* JS dependency is present).
- Index lines in SKILL.md and AGENTS.md are filtered by referenced path, with orphaned tables and empty sections cleaned up and a Trimmed copy note appended. All rewrites are verified in memory before any write.
- Shared installs (plugin cache, user-level) and the source repo refuse.
- validate.mjs now syntax-checks skill scripts, enforces node: builtin imports only, and asserts trim.mjs lists every references/sdks file.
- marketplace.json gains .csproj and Podfile relevance signals for parity.
- README documents the trim flow and pins snyk-agent-scan 0.5.17 for the tokenless demo scan (newer versions are rejected by the demo endpoint).

AI Disclosure 
Claude Opus 5 wrote to the code under my direction. 