### PR TITLE
feat: sync from docs, add log reference page coverage (powersync-docs #631)

### DIFF
--- a/skills/powersync/references/powersync-debug.md
+++ b/skills/powersync/references/powersync-debug.md
@@ -2,7 +2,7 @@
 name: powersync-debug
 description: PowerSync debugging and troubleshooting — sync status, JWT verification, PSYNC error codes, replication lag, and diagnostics tools
 metadata:
-  tags: debugging, troubleshooting, sync-status, jwt, psync-errors, replication-lag, ps-crud, diagnostics
+  tags: debugging, troubleshooting, sync-status, jwt, psync-errors, replication-lag, ps-crud, diagnostics, log-reference, close-reason, checkpoint, flushed, sync-stream-started, sync-stream-complete
 ---
 
 # PowerSync Debug
@@ -287,6 +287,8 @@ Structured log properties are available under `flushed` on each entry:
 | `duration` | Write time in milliseconds. |
 | `replication_lag_seconds` | Age of the oldest uncommitted change in this batch, in seconds. Only present when the Service can determine this value. |
 
+Flush counts can differ across fields. For example, `0 ops, 0 index entries, 2000 records` means the Service wrote source records without bucket operations or parameter index entries. A flush alone does not confirm a committed checkpoint or delivery to a client.
+
 For source-specific guidance (Postgres, MongoDB, MySQL, SQL Server) see [Replication Lag](https://docs.powersync.com/maintenance-ops/replication-lag) and [Replication Lag Debugging (Postgres)](#replication-lag-debugging-postgres) below.
 
 ### Stage 2: PowerSync Service to Client
@@ -299,6 +301,18 @@ Sync & API logs record two events per sync session:
 Both events share the same `rid`; to match a started/complete pair for a single session, search `rid:<request-id>` in the dashboard **Logs** view. To find a specific user's sessions, search `user_id:<user-id>`. If a known error is producing noise, prefix the filter with `-` to exclude matching entries. For example, `-error:PSYNC_S2106` hides all entries with that error code.
 
 [Custom metadata](https://docs.powersync.com/maintenance-ops/monitoring-and-alerting#custom-metadata-in-sync-logs) set at `connect()` time appears in both events, enabling filtering by app version, environment, or other context.
+
+The `close_reason` field on stream complete records why the session ended:
+
+| Value | Meaning |
+|-------|--------|
+| `client closing stream` | Client side closed the connection. Check client-side logs for why. |
+| `service closing stream` | Service ended the stream (token expired or Sync Config switch). |
+| `stream error` | Error interrupted the stream. Read the error logged for the same `rid`. |
+| `process shutdown` | Process shutting down, for example during a deploy. |
+| `unknown` | Service did not identify a close reason. Check nearby messages for the same `rid`. |
+
+For a full reference of all Service log messages and their structured fields, see [Log Reference](https://docs.powersync.com/debugging/log-reference).
 
 ### Common Causes
 


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/631

**Release impact:** `feat`, because `metadata.tags` gains six new trigger terms (`log-reference`, `close-reason`, `checkpoint`, `flushed`, `sync-stream-started`, `sync-stream-complete`). Tag changes affect whether agents find this file when asked about log fields, so a minor release is warranted even though the prose additions are small.

### What changed in docs

PR #631 introduced a new dedicated log reference page (`/debugging/log-reference`) covering all PowerSync Service log messages, their structured fields, and `close_reason` values. It also clarified that `Flushed` batch counts can differ across fields (for example, ops and index entries can be zero while source records are non-zero).

### Skill updates in this PR

- `skills/powersync/references/powersync-debug.md`: Three targeted changes:
  1. **Tags**: added `log-reference`, `close-reason`, `checkpoint`, `flushed`, `sync-stream-started`, `sync-stream-complete` so agents surface this file when asked about log messages or session lifecycle events.
  2. **`close_reason` table**: added a table of `close_reason` values (`client closing stream`, `service closing stream`, `stream error`, `process shutdown`, `unknown`) to the Stage 2 session section. The field was already listed but its values were not documented in the skill.
  3. **Flush count clarification**: added a note that flush counts can differ across fields (e.g. `0 ops, 0 index entries, 2000 records`), and that a flush alone does not confirm a committed checkpoint or delivery to a client.
  4. **Log Reference link**: added a pointer to the new `/debugging/log-reference` docs page at the end of the Stage 2 section.

### Notes for reviewer

No new skill reference file was created for the log reference content. The new docs page is comprehensive (session lifecycle messages, checkpoint events, replicator messages, WAL budget messages, incremental reprocessing messages). Adding a dedicated `powersync-log-reference.md` skill file was considered, but the right shape is not obvious: the docs page is a lookup table for operators reading live logs, whereas the skill is a decision aid for agents generating or debugging code. The existing debug file already covers the actionable subset (what to search for, how to read session fields, when to check Stage 1 vs Stage 2). The tags added here route log-related queries to that file.

The `.claude/CLAUDE.md` and `.claude/skills/` changes in the docs PR are internal to the docs repo and have no impact on agent-skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153aGTuiT4f78G7KgP86vuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0153aGTuiT4f78G7KgP86vuJ)_