### PR TITLE
fix: sync from docs, add max_concurrent_connections capacity note for S3 + storage v4 (powersync-docs #634)

### DIFF
--- a/skills/powersync/references/powersync-service.md
+++ b/skills/powersync/references/powersync-service.md
@@ -232,6 +232,8 @@ storage:
     secret_access_key: !env PS_S3_SECRET
 ```
 
+When S3 object storage is enabled, you can raise `max_concurrent_connections` above the default of 200 per API process. With storage version 4 and S3 enabled, each API process supports up to 1,000 concurrent client connections. If a large share of those clients run an initial sync at the same time, performance degrades; scale out the API before any deployment that forces all clients to re-download their data.
+
 #### Storage Version Default
 
 To control which storage version the Service uses for new sync config deployments (available since Service v1.26.0), set `storage.default_storage_version`. Even numbers are stable; odd numbers are experimental:
@@ -308,7 +310,7 @@ A single replication instance handles roughly 50,000–100,000 concurrent client
 Prometheus metrics are exposed on port `9464`. Enable the chart's `NetworkPolicy` (`networkPolicy.enabled: true`) in production to allow scrapes on that port. Key signals:
 
 | Metric | Note |
-|--------|------|
+|--------|-----------|
 | `powersync_concurrent_connections` | Primary HPA driver. Alert when a pod nears the 200 hard cap. |
 | `powersync_replication_lag_seconds` | Alert on sustained spikes. |
 | `powersync_replication_storage_size_bytes` | Capacity-plan from the trend. |


### PR DESCRIPTION
> _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/634

**Release impact:** `fix`, updates existing prose in an existing section with no tag or routing changes.

### What changed in docs

PR #634 added specific capacity guidance for `max_concurrent_connections`: with storage version 4 and S3 object storage, each API process supports up to 1,000 concurrent client connections (up from the default 200). It also added a note that performance degrades when a large share of those clients run an initial sync at the same time, and to scale out the API before deployments that force all clients to re-download their data.

### Skill updates in this PR

- `skills/powersync/references/powersync-service.md`: Added a paragraph after the S3 object storage YAML example, explaining the 1,000 concurrent connections ceiling per API process and the initial-sync scaling guidance.

### Notes for reviewer

This PR modifies the same file as open PR #101, which covers the broader storage version 4 changes from docs PR #611. The two PRs may conflict on that file. Merging PR #101 first, then rebasing this PR on top, is the recommended order.

The bucket region guidance in docs PR #634 also changed (from "must be in same region" to "where possible"). The skill's S3 section has no same-region requirement text, so no edit was needed for that change.

The Kubernetes Key Constraints table still lists "hard cap is 200" without a v4 qualifier. With storage v4 and S3, the cap rises to 1,000 via `max_concurrent_connections`. Updating that table row was left for PR #101 to decide, since #101 already restructures the S3 section. If #101 does not address the table, a follow-up is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHbctSmbJNDiq47uqixAiD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHbctSmbJNDiq47uqixAiD)_