### PR TITLE
fix: create dedicated powersync_role on the Supabase onboarding path

### DIFF
--- a/skills/powersync/AGENTS.md
+++ b/skills/powersync/AGENTS.md
@@ -158,6 +158,7 @@ Do not proceed to app-side code until **all** items below are verified:
 - Client auth is configured
 - Instance URL is available for `fetchCredentials()`
 - Source database replication/publication setup is complete
+- The replication connection uses a dedicated user (e.g. `powersync_role` on Supabase/Postgres), not a superuser or admin account
 - All credentials and URLs are in `.env` (e.g. `POWERSYNC_URL`, `PS_DATABASE_URI`, plus any backend-specific keys)
 
 Missing item? Finish service setup first. Use the CLI to verify and complete. For steps the agent cannot perform (e.g. running SQL in the source DB), present the exact commands and ask the operator to confirm completion before writing app code.

--- a/skills/powersync/references/onboarding-supabase.md
+++ b/skills/powersync/references/onboarding-supabase.md
@@ -36,9 +36,9 @@ Follow this sequence exactly. **Do not skip ahead to app code.**
 
 1. **Confirm the path.** PowerSync Cloud + Supabase + your platform.
 
-2. **Keep credentials in `.env`, never hardcoded.** As soon as Supabase project details are available, record `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `PS_DATABASE_URI`, and `POWERSYNC_URL` in `.env`. Both `service.yaml` (via `!env` tags) and app code depend on these values. For how to get `POWERSYNC_URL`, see `references/powersync-cli.md` § "Getting POWERSYNC_URL". New Supabase projects use publishable keys (prefixed `sb_publishable_…`) instead of the legacy anon key — use it as the value for `SUPABASE_ANON_KEY`.
+2. **Keep credentials in `.env`, never hardcoded.** As soon as Supabase project details are available, record `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `PS_DATABASE_URI`, and `POWERSYNC_URL` in `.env`. Both `service.yaml` (via `!env` tags) and app code depend on these values. For how to get `POWERSYNC_URL`, see `references/powersync-cli.md` § "Getting POWERSYNC_URL". New Supabase projects use publishable keys (prefixed `sb_publishable_…`) instead of the legacy anon key — use it as the value for `SUPABASE_ANON_KEY`. `PS_DATABASE_URI` must connect as the dedicated `powersync_role` created in step 3, never as the `postgres` superuser.
 
-3. **Run the Supabase publication SQL.** The publication must exist before PowerSync connects to the database. See `references/supabase-auth.md` § "Supabase Database Setup" for the exact SQL. Present it to the operator and ask them to confirm.
+3. **Run the Supabase replication role + publication SQL.** Both must exist before PowerSync connects to the database. See `references/supabase-auth.md` § "Supabase Database Setup" for the exact SQL (dedicated `powersync_role` + publication). Present it to the operator and ask them to confirm.
 
 4. **Scaffold and configure PowerSync.**
    - **New instance (CLI):** `powersync init cloud` → edit config → `powersync link cloud --create --project-id=<id>` → deploy
@@ -65,6 +65,7 @@ Do not proceed to app code until all items are verified:
 
 - [ ] PowerSync instance exists and is running
 - [ ] Source database connection is configured
+- [ ] Dedicated `powersync_role` exists and `PS_DATABASE_URI` connects as it (not the `postgres` user)
 - [ ] Supabase publication exists for synced tables
 - [ ] Sync config is deployed with `config: edition: 3`
 - [ ] Client auth is configured for Supabase

--- a/skills/powersync/references/supabase-auth.md
+++ b/skills/powersync/references/supabase-auth.md
@@ -1,13 +1,13 @@
 ---
 name: supabase-auth
-description: Configuring PowerSync with Supabase — database publication setup, JWT signing keys, Cloud dashboard setup, self-hosted service.yaml config, fetchCredentials() implementation, and error codes
+description: Configuring PowerSync with Supabase — replication role and publication setup, JWT signing keys, Cloud dashboard setup, self-hosted service.yaml config, fetchCredentials() implementation, and error codes
 metadata:
-  tags: supabase, auth, jwt, jwks, client_auth, fetchCredentials, authentication, hs256, rs256, publication, replica-identity
+  tags: supabase, auth, jwt, jwks, client_auth, fetchCredentials, authentication, hs256, rs256, publication, replica-identity, powersync_role, replication-role
 ---
 
 # PowerSync + Supabase Auth
 
-> **Load this when** using Supabase as the backend — covers database publication setup, JWT signing keys, fetchCredentials(), uploadData error handling, and Cloud/self-hosted auth config.
+> **Load this when** using Supabase as the backend — covers replication role and publication setup, JWT signing keys, fetchCredentials(), uploadData error handling, and Cloud/self-hosted auth config.
 
 ## Table of Contents
 - [Supabase Database Setup](#supabase-database-setup)
@@ -21,7 +21,25 @@ PowerSync verifies Supabase JWTs directly when connected to a Supabase-hosted Po
 
 ## Supabase Database Setup
 
-Supabase already has logical replication enabled at the WAL level. You still need to create a publication so PowerSync knows which tables to replicate, and set `REPLICA IDENTITY FULL` on each table so that DELETE operations include the full row (required for PowerSync to sync deletes to clients).
+Supabase already has logical replication enabled at the WAL level. You still need to create a dedicated replication role for PowerSync to connect with, and a publication so PowerSync knows which tables to replicate. Set `REPLICA IDENTITY FULL` on each table so that DELETE operations include the full row (required for PowerSync to sync deletes to clients).
+
+### Replication Role
+
+Never connect PowerSync as the `postgres` superuser. Create a dedicated `powersync_role` with only the privileges PowerSync needs, and use it in `PS_DATABASE_URI`.
+
+Run this in the Supabase SQL Editor (replace the password with a generated secure value, e.g. `openssl rand -base64 32`; do NOT use "secure_password"):
+
+```sql
+-- Dedicated replication role for PowerSync (never use the postgres superuser)
+-- BYPASSRLS: PowerSync replicates whole tables; row filtering happens in the sync config
+CREATE ROLE powersync_role WITH REPLICATION BYPASSRLS LOGIN PASSWORD 'YOUR_GENERATED_PASSWORD';
+
+-- Read-only access to the tables PowerSync replicates
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO powersync_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO powersync_role;
+```
+
+### Publication
 
 Run this in the Supabase SQL Editor **after creating your tables**:
 
@@ -164,6 +182,8 @@ replication:
 Without this you will see: `Replication error postgres does not support ssl`.
 
 Local Supabase database credentials are printed by `supabase status`. Supply the password to the PowerSync service container via the `PS_SUPABASE_DB_PASSWORD` environment variable. The service only substitutes `!env` variables whose names start with `PS_`.
+
+Connecting as the default `postgres` user is acceptable for this throwaway local container only. Hosted Supabase projects must use the dedicated `powersync_role` (see § "Supabase Database Setup").
 
 You can verify your local Supabase is using ES256 by checking:
 ```bash


### PR DESCRIPTION
The Supabase onboarding path never instructed agents to create a dedicated replication role, so setups connected PowerSync with the postgres superuser and still passed every readiness gate.

- supabase-auth.md: add a Replication Role section (CREATE ROLE powersync_role WITH REPLICATION BYPASSRLS LOGIN + scoped GRANT SELECT) ahead of the publication SQL, matching the official Supabase integration guide. This also repairs the previously dangling terraform.md pointer to this file for role setup. Add a note that the default postgres user is acceptable for local dev containers only.
- onboarding-supabase.md: step 3 now covers role + publication SQL, step 2 requires PS_DATABASE_URI to connect as powersync_role, and the Phase 2 gate checks the role exists and the URI uses it.
- AGENTS.md: Cloud Readiness Gate checks the replication connection uses a dedicated user, not a superuser or admin account.

Fixes #80

AI Disclosure
This PR was written by Claude Opus and verified by myself. 