### PR TITLE
feat: sync from docs, add syncStream subscribe pattern to Dart and Swift SDK references (powersync-docs #638)

### DIFF
--- a/skills/powersync/references/sdks/powersync-dart.md
+++ b/skills/powersync/references/sdks/powersync-dart.md
@@ -2,7 +2,7 @@
 name: powersync-dart
 description: PowerSync Dart SDK — schema, queries, sync lifecycle, backend connectors, Drift ORM, Flutter Web support, and encryption
 metadata:
-  tags: dart, flutter, flutter-web, drift, orm, sqlite, encryption, sqlcipher, sqlite3mc, checkpoint-requests
+  tags: dart, flutter, flutter-web, drift, orm, sqlite, encryption, sqlcipher, sqlite3mc, checkpoint-requests, sync-streams, syncStream
 ---
 
 # PowerSync Dart SDK
@@ -143,7 +143,26 @@ If statement preparation overhead is visible in profiling, set `preparedStatemen
 
 ## Sync Streams
 
-See [sync-config.md](references/sync-config.md) for how to subscribe to Sync Streams when `auto_subscribe` is not set to `true` in the PowerSync Service config.
+Sync Streams define what data syncs to each client. See [sync-config.md](references/sync-config.md) for server-side configuration (YAML definitions, parameters, CTEs).
+
+If `auto_subscribe` is not set to `true` in the sync config, subscribe to streams from client code:
+
+```dart
+// Subscribe to a stream with parameters
+final sub = await db.syncStream('list_todos', {'list_id': listId}).subscribe();
+
+// Wait for this specific stream to complete its first sync
+await sub.waitForFirstSync();
+
+// The stream's rows are now in the local SQLite database.
+// Read the data with a local query:
+final rows = await db.getAll('SELECT * FROM todos WHERE list_id = ?', [listId]);
+
+// When the stream is no longer needed
+sub.unsubscribe();
+```
+
+Same stream name with different parameters creates separate subscriptions. Subscribing while offline is supported. For full details see [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md).
 
 ## Checkpoint Requests (Alpha)
 
@@ -303,7 +322,7 @@ See [Flutter Web Support](https://docs.powersync.com/client-sdks/frameworks/flut
 Two options are available for encrypting the local SQLite database at rest:
 
 | Option | Platforms |
-|--------|----------|
+|--------|-----------|
 | [SQLite3MultipleCiphers](https://utelle.github.io/SQLite3MultipleCiphers) | Native + web |
 | [SQLCipher Community Edition](https://www.zetetic.net/sqlcipher/) | Native only |
 

--- a/skills/powersync/references/sdks/powersync-swift.md
+++ b/skills/powersync/references/sdks/powersync-swift.md
@@ -2,7 +2,7 @@
 name: powersync-swift
 description: PowerSync Swift SDK: schema, queries, sync lifecycle, ObservableSyncStatus for SwiftUI, app groups/extensions (v1.15+), backend connectors, GRDB ORM support, and Swift Data community integration
 metadata:
-  tags: swift, ios, macos, grdb, orm, sqlite, offline-first, swift-data, app-groups, observable-sync-status, checkpoint-requests
+  tags: swift, ios, macos, grdb, orm, sqlite, offline-first, swift-data, app-groups, observable-sync-status, checkpoint-requests, sync-streams, syncStream
 description: PowerSync Swift SDK: schema, queries, sync lifecycle, checkpoint requests, backend connectors, GRDB ORM support, and Swift Data community integration
 ---
 
@@ -157,7 +157,26 @@ Multi-process access introduces constraints:
 
 ## Sync Streams
 
-See [sync-config.md](references/sync-config.md) for how to subscribe to Sync Streams when `auto_subscribe` is not set to `true` in the PowerSync Service config.
+Sync Streams define what data syncs to each client. See [sync-config.md](references/sync-config.md) for server-side configuration (YAML definitions, parameters, CTEs).
+
+If `auto_subscribe` is not set to `true` in the sync config, subscribe to streams from client code:
+
+```swift
+// Subscribe to a stream with parameters
+let sub = try await db.syncStream(name: "list_todos", params: ["list_id": .string(listId)]).subscribe()
+
+// Wait for this specific stream to complete its first sync
+try await sub.waitForFirstSync()
+
+// The stream's rows are now in the local SQLite database.
+// Read the data with a local query:
+let rows = try await db.getAll("SELECT * FROM todos WHERE list_id = ?", parameters: [listId])
+
+// When the stream is no longer needed
+try await sub.unsubscribe()
+```
+
+Same stream name with different parameters creates separate subscriptions. Subscribing while offline is supported. For full details see [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md).
 
 ## Checkpoint Requests (Alpha)
 


### PR DESCRIPTION
 > _Generated by Claude. Review carefully before merging._

**Source docs PR:** https://github.com/powersync-ja/powersync-docs/pull/638

**Release impact:** `feat:`, tag changes (`sync-streams`, `syncStream` added to two files) affect skill routing and require a minor release even though the prose diff is small.

### What changed in docs

PR #638 added `syncStream().subscribe()` / `waitForFirstSync()` / `unsubscribe()` subscription examples to every SDK reference page, replacing a stub that only said "see sync-config.md". It also removed Sync Rules mentions from the SDK references and documented Rust sync stream subscription for the first time.

### Skill updates in this PR

- `skills/powersync/references/sdks/powersync-dart.md`: Replaced the single-line Sync Streams stub with an actual code example showing `db.syncStream(...).subscribe()`, `await sub.waitForFirstSync()`, and `sub.unsubscribe()`. Added `sync-streams, syncStream` to `metadata.tags`.
- `skills/powersync/references/sdks/powersync-swift.md`: Same change for Swift. Added `sync-streams, syncStream` to `metadata.tags`.

### Notes for reviewer

The JS (`powersync-js.md`), Kotlin (`powersync-kotlin.md`), and .NET (`powersync-dotnet.md`) skill files already have complete sync stream subscription sections, so no changes were needed there.

The docs PR added Rust sync stream subscription examples for the first time. No `powersync-rust.md` skill file exists, and the PR's one code snippet is not enough to establish the full shape of that file. The gap is noted here for the maintainer: a Rust SDK reference file would need schema, connector, query, and write patterns before it can be added alongside routing entries in `AGENTS.md` and `SKILL.md`.

The docs PR also ran style and clarity passes over the SDK reference pages and removed Sync Rules mentions. Those prose changes have no behavior impact on agents, so they are not reflected here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EELQ5e9XPS7Bnz8DBAzDXA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EELQ5e9XPS7Bnz8DBAzDXA)_